### PR TITLE
replace deprecated pd.DataFrame.append() method calls

### DIFF
--- a/merge_data.py
+++ b/merge_data.py
@@ -3,6 +3,7 @@ import pandas as pd
 import os
 import datetime as dt
 
+
 def merge_data():
     ### Loading data
 
@@ -13,14 +14,14 @@ def merge_data():
     ### From scotgov csv
     source_scotgov = pd.read_csv('data/scotgov-datasets.csv')
     source_scotgov = source_scotgov.rename(columns={
-                                                    'title':'Title',
-                                                    'category':'OriginalTags',
-                                                    'organization':'Owner',
-                                                    'notes':'Description',
-                                                    'date_created':'DateCreated',
-                                                    'date_updated':'DateUpdated',
-                                                    'url':'PageURL'
-                                                    })
+        'title': 'Title',
+        'category': 'OriginalTags',
+        'organization': 'Owner',
+        'notes': 'Description',
+        'date_created': 'DateCreated',
+        'date_updated': 'DateUpdated',
+        'url': 'PageURL'
+    })
     source_scotgov['Source'] = 'manual extraction'
     source_scotgov['License'] = 'OGL3'
 
@@ -29,8 +30,9 @@ def merge_data():
     folder = 'data/arcgis/'
     for dirname, _, filenames in os.walk(folder):
         for filename in filenames:
-            if filename.rsplit('.',1)[1] == 'csv':
-                source_arcgis = source_arcgis.append(pd.read_csv(folder + r'/' + filename, parse_dates=['DateUpdated']))
+            if filename.rsplit('.', 1)[1] == 'csv':
+                source_arcgis = pd.concat([source_arcgis,
+                                           pd.read_csv(folder + r'/' + filename, parse_dates=['DateUpdated'])])
     source_arcgis['Source'] = 'arcgis API'
 
     ### From usmart api
@@ -38,8 +40,9 @@ def merge_data():
     folder = 'data/USMART/'
     for dirname, _, filenames in os.walk(folder):
         for filename in filenames:
-            if filename.rsplit('.',1)[1] == 'csv':
-                source_usmart = source_usmart.append(pd.read_csv(folder + r'/' + filename, parse_dates=['DateUpdated']))
+            if filename.rsplit('.', 1)[1] == 'csv':
+                source_usmart = pd.concat(
+                    [source_usmart, pd.read_csv(folder + r'/' + filename, parse_dates=['DateUpdated'])])
     source_usmart['Source'] = 'USMART API'
     source_usmart['DateUpdated'] = source_usmart['DateUpdated'].apply(lambda x: x.replace(tzinfo=None))
 
@@ -48,9 +51,10 @@ def merge_data():
     folder = 'data/dcat/'
     for dirname, _, filenames in os.walk(folder):
         for filename in filenames:
-            if filename.rsplit('.',1)[1] == 'csv':
-                source_dcat = source_dcat.append(pd.read_csv(folder + r'/' + filename, parse_dates=['DateUpdated']))
-                #source_dcat['DateUpdated'] = source_dcat['DateUpdated'].dt.tz_convert(None)
+            if filename.rsplit('.', 1)[1] == 'csv':
+                source_dcat = pd.concat(
+                    [source_dcat, pd.read_csv(folder + r'/' + filename, parse_dates=['DateUpdated'])])
+                # source_dcat['DateUpdated'] = source_dcat['DateUpdated'].dt.tz_convert(None)
     source_dcat['Source'] = 'DCAT feed'
 
     ## From web scraped results
@@ -58,12 +62,13 @@ def merge_data():
     folder = 'data/scraped-results/'
     for dirname, _, filenames in os.walk(folder):
         for filename in filenames:
-            if filename.rsplit('.',1)[1] == 'csv':
-                source_scraped = source_scraped.append(pd.read_csv(folder + r'/' + filename, parse_dates=['DateUpdated']))
+            if filename.rsplit('.', 1)[1] == 'csv':
+                source_scraped = pd.concat(
+                    [source_scraped, pd.read_csv(folder + r'/' + filename, parse_dates=['DateUpdated'])])
     source_scraped['Source'] = 'Web Scraped'
 
     ### Combine all data into single table
-    data = source_ckan.append([source_arcgis, source_usmart, source_scotgov, source_dcat, source_scraped])
+    data = pd.concat([source_ckan, source_arcgis, source_usmart, source_scotgov, source_dcat, source_scraped])
     data = data.reset_index(drop=True)
 
     ### Saves copy of data without cleaning - for analysis purposes
@@ -76,6 +81,7 @@ def merge_data():
     data.to_csv('data/merged_output.csv', index=False)
 
     return data
+
 
 def clean_data(dataframe):
     """cleans data in a dataframe
@@ -91,17 +97,17 @@ def clean_data(dataframe):
 
     ### Renaming entries to match
     owner_renames = {
-                    'Aberdeen': 'Aberdeen City Council',
-                    'Dundee': 'Dundee City Council',
-                    'Perth': 'Perth and Kinross Council',
-                    'Stirling': 'Stirling Council',
-                    'Angus': 'Angus Council',
-                    'open.data@southayrshire':'South Ayrshire Council',
-                    'SEPA': 'Scottish Environment Protection Agency',
-                    'South Ayrshire': 'South Ayrshire Council',
-                    'East Ayrshire': 'East Ayrshire Council',
-                    'Highland Council GIS Organisation': 'Highland Council'
-                    }
+        'Aberdeen': 'Aberdeen City Council',
+        'Dundee': 'Dundee City Council',
+        'Perth': 'Perth and Kinross Council',
+        'Stirling': 'Stirling Council',
+        'Angus': 'Angus Council',
+        'open.data@southayrshire': 'South Ayrshire Council',
+        'SEPA': 'Scottish Environment Protection Agency',
+        'South Ayrshire': 'South Ayrshire Council',
+        'East Ayrshire': 'East Ayrshire Council',
+        'Highland Council GIS Organisation': 'Highland Council'
+    }
     data['Owner'] = data['Owner'].replace(owner_renames)
     ### Format dates as datetime type
     data['DateUpdated'] = pd.to_datetime(data['DateUpdated'], format='%Y-%m-%d', errors='coerce', utc=True).dt.date
@@ -110,7 +116,6 @@ def clean_data(dataframe):
     ### Creating a dummy column
     data['AssetStatus'] = None
 
-
     ### Cleaning dataset categories
     def tidy_categories(categories_string):
         """tidies the categories: removes commas, strips whitespace, converts all to lower and strips any trailing ";"
@@ -118,11 +123,11 @@ def clean_data(dataframe):
         Args:
             categories_string (string): the dataset categories as a string
         """
-        tidied_string = str(categories_string).replace(',',';')
-        tidied_list = [cat.lower().strip() for cat in tidied_string.split(';') if cat!=""]
-        tidied_string=";".join(str(cat) for cat in tidied_list if str(cat)!='nan')
-        if (len(tidied_string)>0):
-            if (tidied_string[-1]==";"):
+        tidied_string = str(categories_string).replace(',', ';')
+        tidied_list = [cat.lower().strip() for cat in tidied_string.split(';') if cat != ""]
+        tidied_string = ";".join(str(cat) for cat in tidied_list if str(cat) != 'nan')
+        if (len(tidied_string) > 0):
+            if (tidied_string[-1] == ";"):
                 tidied_string = tidied_string[:-1]
         return tidied_string
 
@@ -134,9 +139,9 @@ def clean_data(dataframe):
             dataset_row (dataframe): one row of the dataset set
         """
         combined_tags = []
-        if str(dataset_row['OriginalTags'])!='nan':
+        if str(dataset_row['OriginalTags']) != 'nan':
             combined_tags = combined_tags + str(dataset_row['OriginalTags']).split(';')
-        if str(dataset_row['ManualTags'])!='nan':
+        if str(dataset_row['ManualTags']) != 'nan':
             combined_tags = combined_tags + str(dataset_row['ManualTags']).split(';')
 
         combined_tags = ";".join(str(cat) for cat in set(combined_tags))
@@ -144,7 +149,7 @@ def clean_data(dataframe):
 
     data['OriginalTags'] = data['OriginalTags'].apply(tidy_categories)
     data['ManualTags'] = data['ManualTags'].apply(tidy_categories)
-    data['CombinedTags'] = data.apply(lambda x: combine_categories(x),axis=1)
+    data['CombinedTags'] = data.apply(lambda x: combine_categories(x), axis=1)
 
     ### Creating new dataset categories for ODS
     def assign_ODScategories(categories_string):
@@ -156,23 +161,86 @@ def clean_data(dataframe):
         combined_tags = categories_string.split(';')
 
         ### Set association between dataset tag and ODS category
-        ods_categories={
-            'Arts / Culture / History':['arts','culture','history','military','art gallery','design','fashion','museum','historic centre','conservation', 'archaeology', 'events','theatre'],
-            'Budget / Finance':['tenders', 'contracts','lgcs finance','budget','finance','payment','grants','financial year', 'council tax'],
-            'Business and Economy':['business and economy','business', 'business and trade', 'economic information', 'economic development', 'business grants', 'business awards', 'health and safety', 'trading standards', 'food safety', 'business rates', 'commercial land and property' 'commercial waste', 'pollution', 'farming', 'forestry', 'crofting', 'countryside', 'farming', 'emergency planning', 'health and safety', 'trading standards', 'health and safety at work', 'regeneration', 'shopping', 'shopping centres', 'markets', 'tenders', 'contracts', 'city centre management', 'town centre management','economy','economic','economic activity','economic development','deprivation','scottish index of multiple deprivation','simd','business','estimated population','population','labour force'],
-            'Council and Government':['council buildings','community development','council and government','council', 'councils', 'council tax', 'benefits', 'council grants', 'grants', 'council departments', 'data protection', 'FOI', 'freedom of information', 'council housing', 'politicians', 'MPs', 'MSPs', 'councillors', 'elected members', 'wards', 'constituencies', 'boundaries', 'council minutes', 'council agendas', 'council plans', 'council policies'],
-            'Education':['primary schools','lgcs education & skills','education','eductional','library','school meals','schools','school', 'nurseries', 'playgroups',],
-            'Elections / Politics':['community councils','political','polling places','elections','politics','elecorate','election','electoral','electorate','local authority','council area','democracy','polling','lgcs democracy','democracy and governance','local government', 'councillor', 'councillors','community council'],
-            'Food and Environment':['food','school meals','allotment','public toilets','air','tree','vacant and derelict land supply','landscape','nature','rights of way','tree preservation order','preservation','land','contaminated','green', 'belt','employment land audit','environment','forest woodland strategy','waste','recycling','lgcs waste management','water-network', 'grafitti', 'street occupations', 'regeneration','vandalism','street cleansing', 'litter', 'toilets', 'drains','flytipping', 'flyposting','pollution', 'air quality', 'household waste', 'commercial waste'],
-            'Health and Social Care':['public toilets','contraception', 'implant','cervical','iud','ius','pis','prescribing','elderly','screening','screening programme','cancer','breast feeding','defibrillators','wards','alcohol and drug partnership', 'care homes', 'waiting times', 'drugs', 'substance use', 'pregnancy', 'induced abortion','therapeutic abortion','termination', 'abortion','co-dependency','sexual health', 'outpatient','waiting list', 'stage of treatment', 'daycase','inpatient', 'alcohol','waiting time','treatment','community wellbeing and social environment','health','human services', 'covid-19','covid','hospital','health board', 'health and social care partnership','medicine','health and social care','health and fitness','nhs24','hospital admissions','hospital mortality', 'mental health', 'pharmacy', 'GP', 'surgery','fostering','adoption', 'social work', 'asylum', 'immigration', 'citizenship', 'carers'],
-            'Housing and Estates':['buildings','housing data supply 2020','multiple occupation', 'housing', 'sheltered housing', 'adaptations', 'repairs', 'council housing', 'landlord', 'landlord registration', 'rent arrears', 'parking', 'garages', 'homelessness', 'temporary accommodation', 'rent', 'tenancy', 'housing advice', 'housing associations', 'housing advice', 'housing repairs', 'lettings','real estate','land records','land-cover','woodland','dwellings','burial grounds','cemeteries','property','vacant and derelict land','scottish vacant and derelict land','allotment'],
-            'Law and Licensing':['law', 'licensing', 'regulation', 'regulations', 'licence', 'licenses', 'permit', 'permits', 'police', 'court', 'courts', 'tribunal', 'tribunals'],
-            'Parks / Recreation':['parks','recreation','woodland','parks and open spaces'],
-            'Planning and Development':['buildings','vacant and derelict land supply','core paths. adopted', 'employment land audit','built environment','planning','zoning','council area','address','addresses','city development plan','boundaries','post-code','dwellings','planning permission','postcode-units','housing','property', 'building control', 'conservation'],
-            'Public Safety':['emergency planning','public safety','crime and justice','lgcs community safety','street lighting','community safety','cctv','road safety'],
-            'Sport and Leisure':['sport', 'sports', 'sports facilities',' sports activities','countryside', 'wildlife', 'leisure', 'leisure clubs', 'clubs', 'groups', 'societies', 'libraries', 'archives', 'local history', 'heritage', 'museums', 'galleries', 'parks', 'gardens', 'open spaces', 'sports', 'sports clubs', 'leisure centres'],
-            'Tourism':['public toilets','tourism','tourist','attractions','accomodation', 'historic buildings','tourist routes', 'cafes','restaurants', 'hotels','hotel'],
-            'Transportation':['core paths. adopted','lgcs transport infrastructure','transportation','mobility','pedestrian','walking','walk','cycle','cycling','parking','car','bus','tram','train','taxi','transport','electric vehicle','electric vehicle charging points','transport / mobility','active travel','road safety','roads', 'community transport', 'road works', 'road closures','speed limits', 'port', 'harbour']
+        ods_categories = {
+            'Arts / Culture / History': ['arts', 'culture', 'history', 'military', 'art gallery', 'design', 'fashion',
+                                         'museum', 'historic centre', 'conservation', 'archaeology', 'events',
+                                         'theatre'],
+            'Budget / Finance': ['tenders', 'contracts', 'lgcs finance', 'budget', 'finance', 'payment', 'grants',
+                                 'financial year', 'council tax'],
+            'Business and Economy': ['business and economy', 'business', 'business and trade', 'economic information',
+                                     'economic development', 'business grants', 'business awards', 'health and safety',
+                                     'trading standards', 'food safety', 'business rates',
+                                     'commercial land and property' 'commercial waste', 'pollution', 'farming',
+                                     'forestry', 'crofting', 'countryside', 'farming', 'emergency planning',
+                                     'health and safety', 'trading standards', 'health and safety at work',
+                                     'regeneration', 'shopping', 'shopping centres', 'markets', 'tenders', 'contracts',
+                                     'city centre management', 'town centre management', 'economy', 'economic',
+                                     'economic activity', 'economic development', 'deprivation',
+                                     'scottish index of multiple deprivation', 'simd', 'business',
+                                     'estimated population', 'population', 'labour force'],
+            'Council and Government': ['council buildings', 'community development', 'council and government',
+                                       'council', 'councils', 'council tax', 'benefits', 'council grants', 'grants',
+                                       'council departments', 'data protection', 'FOI', 'freedom of information',
+                                       'council housing', 'politicians', 'MPs', 'MSPs', 'councillors',
+                                       'elected members', 'wards', 'constituencies', 'boundaries', 'council minutes',
+                                       'council agendas', 'council plans', 'council policies'],
+            'Education': ['primary schools', 'lgcs education & skills', 'education', 'eductional', 'library',
+                          'school meals', 'schools', 'school', 'nurseries', 'playgroups', ],
+            'Elections / Politics': ['community councils', 'political', 'polling places', 'elections', 'politics',
+                                     'elecorate', 'election', 'electoral', 'electorate', 'local authority',
+                                     'council area', 'democracy', 'polling', 'lgcs democracy',
+                                     'democracy and governance', 'local government', 'councillor', 'councillors',
+                                     'community council'],
+            'Food and Environment': ['food', 'school meals', 'allotment', 'public toilets', 'air', 'tree',
+                                     'vacant and derelict land supply', 'landscape', 'nature', 'rights of way',
+                                     'tree preservation order', 'preservation', 'land', 'contaminated', 'green', 'belt',
+                                     'employment land audit', 'environment', 'forest woodland strategy', 'waste',
+                                     'recycling', 'lgcs waste management', 'water-network', 'grafitti',
+                                     'street occupations', 'regeneration', 'vandalism', 'street cleansing', 'litter',
+                                     'toilets', 'drains', 'flytipping', 'flyposting', 'pollution', 'air quality',
+                                     'household waste', 'commercial waste'],
+            'Health and Social Care': ['public toilets', 'contraception', 'implant', 'cervical', 'iud', 'ius', 'pis',
+                                       'prescribing', 'elderly', 'screening', 'screening programme', 'cancer',
+                                       'breast feeding', 'defibrillators', 'wards', 'alcohol and drug partnership',
+                                       'care homes', 'waiting times', 'drugs', 'substance use', 'pregnancy',
+                                       'induced abortion', 'therapeutic abortion', 'termination', 'abortion',
+                                       'co-dependency', 'sexual health', 'outpatient', 'waiting list',
+                                       'stage of treatment', 'daycase', 'inpatient', 'alcohol', 'waiting time',
+                                       'treatment', 'community wellbeing and social environment', 'health',
+                                       'human services', 'covid-19', 'covid', 'hospital', 'health board',
+                                       'health and social care partnership', 'medicine', 'health and social care',
+                                       'health and fitness', 'nhs24', 'hospital admissions', 'hospital mortality',
+                                       'mental health', 'pharmacy', 'GP', 'surgery', 'fostering', 'adoption',
+                                       'social work', 'asylum', 'immigration', 'citizenship', 'carers'],
+            'Housing and Estates': ['buildings', 'housing data supply 2020', 'multiple occupation', 'housing',
+                                    'sheltered housing', 'adaptations', 'repairs', 'council housing', 'landlord',
+                                    'landlord registration', 'rent arrears', 'parking', 'garages', 'homelessness',
+                                    'temporary accommodation', 'rent', 'tenancy', 'housing advice',
+                                    'housing associations', 'housing advice', 'housing repairs', 'lettings',
+                                    'real estate', 'land records', 'land-cover', 'woodland', 'dwellings',
+                                    'burial grounds', 'cemeteries', 'property', 'vacant and derelict land',
+                                    'scottish vacant and derelict land', 'allotment'],
+            'Law and Licensing': ['law', 'licensing', 'regulation', 'regulations', 'licence', 'licenses', 'permit',
+                                  'permits', 'police', 'court', 'courts', 'tribunal', 'tribunals'],
+            'Parks / Recreation': ['parks', 'recreation', 'woodland', 'parks and open spaces'],
+            'Planning and Development': ['buildings', 'vacant and derelict land supply', 'core paths. adopted',
+                                         'employment land audit', 'built environment', 'planning', 'zoning',
+                                         'council area', 'address', 'addresses', 'city development plan', 'boundaries',
+                                         'post-code', 'dwellings', 'planning permission', 'postcode-units', 'housing',
+                                         'property', 'building control', 'conservation'],
+            'Public Safety': ['emergency planning', 'public safety', 'crime and justice', 'lgcs community safety',
+                              'street lighting', 'community safety', 'cctv', 'road safety'],
+            'Sport and Leisure': ['sport', 'sports', 'sports facilities', ' sports activities', 'countryside',
+                                  'wildlife', 'leisure', 'leisure clubs', 'clubs', 'groups', 'societies', 'libraries',
+                                  'archives', 'local history', 'heritage', 'museums', 'galleries', 'parks', 'gardens',
+                                  'open spaces', 'sports', 'sports clubs', 'leisure centres'],
+            'Tourism': ['public toilets', 'tourism', 'tourist', 'attractions', 'accomodation', 'historic buildings',
+                        'tourist routes', 'cafes', 'restaurants', 'hotels', 'hotel'],
+            'Transportation': ['core paths. adopted', 'lgcs transport infrastructure', 'transportation', 'mobility',
+                               'pedestrian', 'walking', 'walk', 'cycle', 'cycling', 'parking', 'car', 'bus', 'tram',
+                               'train', 'taxi', 'transport', 'electric vehicle', 'electric vehicle charging points',
+                               'transport / mobility', 'active travel', 'road safety', 'roads', 'community transport',
+                               'road works', 'road closures', 'speed limits', 'port', 'harbour']
         }
 
         ### Return ODS if tag is a match
@@ -193,7 +261,6 @@ def clean_data(dataframe):
 
     ### Apply ODS categorisation
     data['ODSCategories'] = data['CombinedTags'].apply(assign_ODScategories)
-
 
     ### Tidy licence names
     def tidy_licence(licence_name):
@@ -237,8 +304,8 @@ def clean_data(dataframe):
 
     data['License'] = data['License'].apply(tidy_licence)
 
+    return data
 
-    return data 
 
-if __name__=="__main__":
+if __name__ == "__main__":
     merge_data()


### PR DESCRIPTION
This _should_ fulfil #115 - merge_data.py now executes without the deprecation warnings, but I can't tell if the logic is directly equivalent from the generated output as this seems to be generated non-deterministically.