### PR TITLE
format python files using black

### DIFF
--- a/arcgis.py
+++ b/arcgis.py
@@ -1,9 +1,10 @@
 from datetime import datetime
 from processor import Processor
 
+
 class ProcessorARCGIS(Processor):
     def __init__(self):
-        super().__init__(type='arcgis')
+        super().__init__(type="arcgis")
 
     def get_datasets(self, owner, start_url, fname):
         datasets = []
@@ -12,9 +13,9 @@ class ProcessorARCGIS(Processor):
 
         while True:
             d = processor.get_json(url)
-            datasets += d['data']
-            if 'next' in d['meta'] and d['meta']['next']:
-                url = d['meta']['next']
+            datasets += d["data"]
+            if "next" in d["meta"] and d["meta"]["next"]:
+                url = d["meta"]["next"]
                 print(f"Next {url}")
             else:
                 break
@@ -23,27 +24,31 @@ class ProcessorARCGIS(Processor):
 
         prepped = []
         for e in datasets:
-            prepped.append([e['attributes'].get('name', ""),
-                            e['attributes'].get('source', ""),
-                            e.get('links', {}).get('itemPage', ""),
-                            "",  # Link to data
-                            datetime.utcfromtimestamp(
-                                e['attributes'].get('created', 0)/1000).strftime(
-                                    '%Y-%m-%d'),
-                            datetime.utcfromtimestamp(
-                                e['attributes'].get('modified', 0)/1000).strftime(
-                                    '%Y-%m-%d'),
-                            # ^^ Should really do something better than defaulting to start of epoch
-                            e['attributes'].get('size', ""),
-                            "bytes",
-                            e['attributes'].get('type', ""),
-                            e['attributes'].get('recordCount', ""),
-                            ";".join(e['attributes'].get('tags', [])),
-                            "",  # Manual tags
-                            self.get_license(e),  # license
-                            e['attributes'].get('searchDescription', "")
-                            ])
+            prepped.append(
+                [
+                    e["attributes"].get("name", ""),
+                    e["attributes"].get("source", ""),
+                    e.get("links", {}).get("itemPage", ""),
+                    "",  # Link to data
+                    datetime.utcfromtimestamp(
+                        e["attributes"].get("created", 0) / 1000
+                    ).strftime("%Y-%m-%d"),
+                    datetime.utcfromtimestamp(
+                        e["attributes"].get("modified", 0) / 1000
+                    ).strftime("%Y-%m-%d"),
+                    # ^^ Should really do something better than defaulting to start of epoch
+                    e["attributes"].get("size", ""),
+                    "bytes",
+                    e["attributes"].get("type", ""),
+                    e["attributes"].get("recordCount", ""),
+                    ";".join(e["attributes"].get("tags", [])),
+                    "",  # Manual tags
+                    self.get_license(e),  # license
+                    e["attributes"].get("searchDescription", ""),
+                ]
+            )
         processor.write_csv(fname, prepped)
-    
+
+
 processor = ProcessorARCGIS()
 processor.process()

--- a/dcat.py
+++ b/dcat.py
@@ -1,60 +1,60 @@
 import copy
 from processor import Processor
 
+
 class ProcessorDCAT(Processor):
     def __init__(self):
-        super().__init__(type='dcat')
+        super().__init__(type="dcat")
 
     def get_datasets(self, owner, start_url, fname):
         d = processor.get_json(start_url)
-        datasets = d['dcat:dataset']
+        datasets = d["dcat:dataset"]
 
         print(f"Found {len(datasets)} datasets")
 
         prepped = []
         for e in datasets:
-            ds = [e.get('dct:title', ""),
-                e.get('dct:publisher', "").replace(" Mapping", ""),
+            ds = [
+                e.get("dct:title", ""),
+                e.get("dct:publisher", "").replace(" Mapping", ""),
                 "",  # link to page
                 "",  # Link to data
                 "",  # date created
-                e.get('dct:issued', ""),
+                e.get("dct:issued", ""),
                 "",  # size
                 "",  # size unit
                 "",  # filetype
                 "",  # numrecords
-                ";".join(e.get('dcat:keyword', [])),
+                ";".join(e.get("dcat:keyword", [])),
                 "",  # Manual tags
                 "",  # license
-                e.get('dct:description', "").strip(u'\u200b')
-                ]
-            pages = e.get('dcat:distribution')
+                e.get("dct:description", "").strip("\u200b"),
+            ]
+            pages = e.get("dcat:distribution")
             for p in pages:
-                if p.get('dct:description', '') == 'Web Page':
-                    ds[2] = p.get('dcat:accessUrl', '')
+                if p.get("dct:description", "") == "Web Page":
+                    ds[2] = p.get("dcat:accessUrl", "")
                     break
             dsl = []
             for p in pages:
-                if p.get('dct:description', '') == 'Web Page':
+                if p.get("dct:description", "") == "Web Page":
                     continue
-                ds[3] = p.get('dcat:accessUrl', '')
-                ds[8] = p.get('dct:title', '')
+                ds[3] = p.get("dcat:accessUrl", "")
+                ds[8] = p.get("dct:title", "")
                 dsl.append(copy.deepcopy(ds))
             if not dsl:
                 dsl.append(ds)
             prepped += dsl
 
-        print(f'{len(prepped)} lines for csv')
+        print(f"{len(prepped)} lines for csv")
         processor.write_csv(fname, prepped)
 
 
 def get_license(dataset):
     try:
-        return dataset['attributes']['structuredLicense']['url']
+        return dataset["attributes"]["structuredLicense"]["url"]
     except:
         return ""
-
-
 
 
 processor = ProcessorDCAT()

--- a/export2jkan.py
+++ b/export2jkan.py
@@ -9,12 +9,14 @@ import shutil
 import os
 import urllib
 
+
 @dataclass
 class DataFile:
     url: str
     size: float
     size_unit: str
     file_type: str
+
 
 @dataclass
 class Dataset:
@@ -29,37 +31,44 @@ class Dataset:
     num_records: int
     files: List[DataFile]
 
+
 fulld = pd.read_csv("data/merged_output.csv", dtype=str, na_filter=False)
+
+
 def ind(name):
-    f = ['Title',
-        'Owner',
-        'PageURL',
-        'AssetURL',
-        'DateCreated',
-        'DateUpdated',
-        'FileName',
-        'FileSize',
-        'FileSizeUnit',
-        'FileType',
-        'NumRecords',
-        'OriginalTags',
-        'ManualTags',
-        'License',
-        'Description',
-        'Source',
-        'AssetStatus',
-        'CombinedTags',
-        'ODSCategories'
-        ]
+    f = [
+        "Title",
+        "Owner",
+        "PageURL",
+        "AssetURL",
+        "DateCreated",
+        "DateUpdated",
+        "FileName",
+        "FileSize",
+        "FileSizeUnit",
+        "FileType",
+        "NumRecords",
+        "OriginalTags",
+        "ManualTags",
+        "License",
+        "Description",
+        "Source",
+        "AssetStatus",
+        "CombinedTags",
+        "ODSCategories",
+    ]
     return f.index(name)
+
 
 def splittags(tags):
     if type(tags) == str:
         if tags == "":
             return []
-        return tags.split(';')
+        return tags.split(";")
     else:
         return []
+
+
 def makeint(val):
     try:
         return int(val)
@@ -70,84 +79,97 @@ def makeint(val):
     except:
         pass
     return None
-    
+
+
 data = {}
 for r in fulld.values:
-    id = str(r[ind('PageURL')]) + r[ind('Title')]
+    id = str(r[ind("PageURL")]) + r[ind("Title")]
     if id not in data:
         ds = Dataset(
-            title = r[ind('Title')],
-            owner = r[ind('Owner')],
-            page_url = r[ind('PageURL')],
-            date_created = r[ind('DateCreated')],
-            date_updated = r[ind('DateUpdated')].removesuffix(' 00:00:00.000'),
-            ods_categories = splittags(r[ind('ODSCategories')]),
-            license = r[ind('License')],
-            description = str(r[ind('Description')]),
-            num_records = makeint(r[ind('NumRecords')]),
-            files = []
+            title=r[ind("Title")],
+            owner=r[ind("Owner")],
+            page_url=r[ind("PageURL")],
+            date_created=r[ind("DateCreated")],
+            date_updated=r[ind("DateUpdated")].removesuffix(" 00:00:00.000"),
+            ods_categories=splittags(r[ind("ODSCategories")]),
+            license=r[ind("License")],
+            description=str(r[ind("Description")]),
+            num_records=makeint(r[ind("NumRecords")]),
+            files=[],
         )
 
         # Sort categories to keep consistent when syncing
         ds.ods_categories.sort()
-        
+
         data[id] = ds
     data[id].files.append(
         DataFile(
-            url = r[ind('AssetURL')],
-            size = r[ind('FileSize')],
-            size_unit = r[ind('FileSizeUnit')],
-            file_type = r[ind('FileType')]
-        ))
+            url=r[ind("AssetURL")],
+            size=r[ind("FileSize")],
+            size_unit=r[ind("FileSizeUnit")],
+            file_type=r[ind("FileType")],
+        )
+    )
 
 
 unknown_lics = []
+
+
 def license_link(l):
-    ogl = ["Open Government Licence 3.0 (United Kingdom)", "uk-ogl",
-           "UK Open Government Licence (OGL)", "OGL3", "Open Government Licence v3.0"]
+    ogl = [
+        "Open Government Licence 3.0 (United Kingdom)",
+        "uk-ogl",
+        "UK Open Government Licence (OGL)",
+        "OGL3",
+        "Open Government Licence v3.0",
+    ]
     if l in ogl:
-        return "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+        return (
+            "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+        )
     if l == "Creative Commons Attribution Share-Alike 4.0":
         return "https://creativecommons.org/licenses/by-sa/4.0/"
     if l == "Creative Commons Attribution 4.0":
         return "https://creativecommons.org/licenses/by/4.0/"
     if l == "Open Data Commons Open Database License 1.0":
         return "https://opendatacommons.org/licenses/odbl/"
-    
+
     if not l in unknown_lics:
         unknown_lics.append(l)
         print("Unknown license: ", l)
     return l
 
+
 md = markdown.Markdown()
 
 ### Replace folder by deleting and writing
-shutil.rmtree('../jkan/_datasets/')
-os.makedirs('../jkan/_datasets/')
+shutil.rmtree("../jkan/_datasets/")
+os.makedirs("../jkan/_datasets/")
 
 
 for n, (k, ds) in enumerate(data.items()):
-    y = {'schema': 'default'}
-    y['title'] = ds.title
-    y['organization'] = ds.owner
-    y['notes'] = markdown.markdown(ds.description)
-    y['original_dataset_link'] = ds.page_url
-    y['resources'] = [{'name': d.file_type,
-                       'url': d.url,
-                       'format': d.file_type} for d in ds.files if d.url]
-    y['license'] = license_link(ds.license)
-    y['category'] = ds.ods_categories
-    y['maintainer'] = ds.owner
-    y['date_created'] = ds.date_created
-    y['date_updated'] = ds.date_updated
-    y['records'] = ds.num_records
-    #fn = f'{ds.owner}-{ds.title}'
-    #fn = re.sub(r'[^\w\s-]', '', fn).strip()[:100]
-    fn = urllib.parse.quote_plus(f'{(ds.owner).lower()}-{(ds.title).lower()}')
-    #fn = {ds.owner}-{ds.title})
+    y = {"schema": "default"}
+    y["title"] = ds.title
+    y["organization"] = ds.owner
+    y["notes"] = markdown.markdown(ds.description)
+    y["original_dataset_link"] = ds.page_url
+    y["resources"] = [
+        {"name": d.file_type, "url": d.url, "format": d.file_type}
+        for d in ds.files
+        if d.url
+    ]
+    y["license"] = license_link(ds.license)
+    y["category"] = ds.ods_categories
+    y["maintainer"] = ds.owner
+    y["date_created"] = ds.date_created
+    y["date_updated"] = ds.date_updated
+    y["records"] = ds.num_records
+    # fn = f'{ds.owner}-{ds.title}'
+    # fn = re.sub(r'[^\w\s-]', '', fn).strip()[:100]
+    fn = urllib.parse.quote_plus(f"{(ds.owner).lower()}-{(ds.title).lower()}")
+    # fn = {ds.owner}-{ds.title})
     # ^^ need something better for filnames...
     with open(f"../jkan/_datasets/{fn}.md", "w") as f:
         f.write("---\n")
         f.write(yaml.dump(y))
         f.write("---\n")
-

--- a/merge_data.py
+++ b/merge_data.py
@@ -3,79 +3,95 @@ import pandas as pd
 import os
 import datetime as dt
 
+
 def merge_data():
     ### Loading data
 
     ### From ckan output
-    source_ckan = pd.read_csv('data/ckan_output.csv', parse_dates=['DateUpdated'])
-    source_ckan['Source'] = 'ckan API'
+    source_ckan = pd.read_csv("data/ckan_output.csv", parse_dates=["DateUpdated"])
+    source_ckan["Source"] = "ckan API"
 
     ### From scotgov csv
-    source_scotgov = pd.read_csv('data/scotgov-datasets.csv')
-    source_scotgov = source_scotgov.rename(columns={
-                                                    'title':'Title',
-                                                    'category':'OriginalTags',
-                                                    'organization':'Owner',
-                                                    'notes':'Description',
-                                                    'date_created':'DateCreated',
-                                                    'date_updated':'DateUpdated',
-                                                    'url':'PageURL'
-                                                    })
-    source_scotgov['Source'] = 'manual extraction'
-    source_scotgov['License'] = 'OGL3'
+    source_scotgov = pd.read_csv("data/scotgov-datasets.csv")
+    source_scotgov = source_scotgov.rename(
+        columns={
+            "title": "Title",
+            "category": "OriginalTags",
+            "organization": "Owner",
+            "notes": "Description",
+            "date_created": "DateCreated",
+            "date_updated": "DateUpdated",
+            "url": "PageURL",
+        }
+    )
+    source_scotgov["Source"] = "manual extraction"
+    source_scotgov["License"] = "OGL3"
 
     ### From arcgis api
     source_arcgis = pd.DataFrame()
-    folder = 'data/arcgis/'
+    folder = "data/arcgis/"
     for dirname, _, filenames in os.walk(folder):
         for filename in filenames:
-            if filename.rsplit('.',1)[1] == 'csv':
-                source_arcgis = source_arcgis.append(pd.read_csv(folder + r'/' + filename, parse_dates=['DateUpdated']))
-    source_arcgis['Source'] = 'arcgis API'
+            if filename.rsplit(".", 1)[1] == "csv":
+                source_arcgis = source_arcgis.append(
+                    pd.read_csv(folder + r"/" + filename, parse_dates=["DateUpdated"])
+                )
+    source_arcgis["Source"] = "arcgis API"
 
     ### From usmart api
     source_usmart = pd.DataFrame()
-    folder = 'data/USMART/'
+    folder = "data/USMART/"
     for dirname, _, filenames in os.walk(folder):
         for filename in filenames:
-            if filename.rsplit('.',1)[1] == 'csv':
-                source_usmart = source_usmart.append(pd.read_csv(folder + r'/' + filename, parse_dates=['DateUpdated']))
-    source_usmart['Source'] = 'USMART API'
-    source_usmart['DateUpdated'] = source_usmart['DateUpdated'].apply(lambda x: x.replace(tzinfo=None))
+            if filename.rsplit(".", 1)[1] == "csv":
+                source_usmart = source_usmart.append(
+                    pd.read_csv(folder + r"/" + filename, parse_dates=["DateUpdated"])
+                )
+    source_usmart["Source"] = "USMART API"
+    source_usmart["DateUpdated"] = source_usmart["DateUpdated"].apply(
+        lambda x: x.replace(tzinfo=None)
+    )
 
     ## From DCAT
     source_dcat = pd.DataFrame()
-    folder = 'data/dcat/'
+    folder = "data/dcat/"
     for dirname, _, filenames in os.walk(folder):
         for filename in filenames:
-            if filename.rsplit('.',1)[1] == 'csv':
-                source_dcat = source_dcat.append(pd.read_csv(folder + r'/' + filename, parse_dates=['DateUpdated']))
-                #source_dcat['DateUpdated'] = source_dcat['DateUpdated'].dt.tz_convert(None)
-    source_dcat['Source'] = 'DCAT feed'
+            if filename.rsplit(".", 1)[1] == "csv":
+                source_dcat = source_dcat.append(
+                    pd.read_csv(folder + r"/" + filename, parse_dates=["DateUpdated"])
+                )
+                # source_dcat['DateUpdated'] = source_dcat['DateUpdated'].dt.tz_convert(None)
+    source_dcat["Source"] = "DCAT feed"
 
     ## From web scraped results
     source_scraped = pd.DataFrame()
-    folder = 'data/scraped-results/'
+    folder = "data/scraped-results/"
     for dirname, _, filenames in os.walk(folder):
         for filename in filenames:
-            if filename.rsplit('.',1)[1] == 'csv':
-                source_scraped = source_scraped.append(pd.read_csv(folder + r'/' + filename, parse_dates=['DateUpdated']))
-    source_scraped['Source'] = 'Web Scraped'
+            if filename.rsplit(".", 1)[1] == "csv":
+                source_scraped = source_scraped.append(
+                    pd.read_csv(folder + r"/" + filename, parse_dates=["DateUpdated"])
+                )
+    source_scraped["Source"] = "Web Scraped"
 
     ### Combine all data into single table
-    data = source_ckan.append([source_arcgis, source_usmart, source_scotgov, source_dcat, source_scraped])
+    data = source_ckan.append(
+        [source_arcgis, source_usmart, source_scotgov, source_dcat, source_scraped]
+    )
     data = data.reset_index(drop=True)
 
     ### Saves copy of data without cleaning - for analysis purposes
-    data.to_csv('data/merged_output_untidy.csv', index=False)
+    data.to_csv("data/merged_output_untidy.csv", index=False)
 
     ### clean data
     data = clean_data(data)
 
     ### Output cleaned data to csv
-    data.to_csv('data/merged_output.csv', index=False)
+    data.to_csv("data/merged_output.csv", index=False)
 
     return data
+
 
 def clean_data(dataframe):
     """cleans data in a dataframe
@@ -91,25 +107,26 @@ def clean_data(dataframe):
 
     ### Renaming entries to match
     owner_renames = {
-                    'Aberdeen': 'Aberdeen City Council',
-                    'Dundee': 'Dundee City Council',
-                    'Perth': 'Perth and Kinross Council',
-                    'Stirling': 'Stirling Council',
-                    'Angus': 'Angus Council',
-                    'open.data@southayrshire':'South Ayrshire Council',
-                    'SEPA': 'Scottish Environment Protection Agency',
-                    'South Ayrshire': 'South Ayrshire Council',
-                    'East Ayrshire': 'East Ayrshire Council',
-                    'Highland Council GIS Organisation': 'Highland Council'
-                    }
-    data['Owner'] = data['Owner'].replace(owner_renames)
+        "Aberdeen": "Aberdeen City Council",
+        "Dundee": "Dundee City Council",
+        "Perth": "Perth and Kinross Council",
+        "Stirling": "Stirling Council",
+        "Angus": "Angus Council",
+        "open.data@southayrshire": "South Ayrshire Council",
+        "SEPA": "Scottish Environment Protection Agency",
+        "South Ayrshire": "South Ayrshire Council",
+        "East Ayrshire": "East Ayrshire Council",
+        "Highland Council GIS Organisation": "Highland Council",
+    }
+    data["Owner"] = data["Owner"].replace(owner_renames)
     ### Format dates as datetime type
-    data['DateUpdated'] = pd.to_datetime(data['DateUpdated'], format='%Y-%m-%d', errors='coerce', utc=True).dt.date
+    data["DateUpdated"] = pd.to_datetime(
+        data["DateUpdated"], format="%Y-%m-%d", errors="coerce", utc=True
+    ).dt.date
     ### Inconsistencies in casing for FileType
-    data['FileType'] = data['FileType'].str.upper()
+    data["FileType"] = data["FileType"].str.upper()
     ### Creating a dummy column
-    data['AssetStatus'] = None
-
+    data["AssetStatus"] = None
 
     ### Cleaning dataset categories
     def tidy_categories(categories_string):
@@ -118,11 +135,13 @@ def clean_data(dataframe):
         Args:
             categories_string (string): the dataset categories as a string
         """
-        tidied_string = str(categories_string).replace(',',';')
-        tidied_list = [cat.lower().strip() for cat in tidied_string.split(';') if cat!=""]
-        tidied_string=";".join(str(cat) for cat in tidied_list if str(cat)!='nan')
-        if (len(tidied_string)>0):
-            if (tidied_string[-1]==";"):
+        tidied_string = str(categories_string).replace(",", ";")
+        tidied_list = [
+            cat.lower().strip() for cat in tidied_string.split(";") if cat != ""
+        ]
+        tidied_string = ";".join(str(cat) for cat in tidied_list if str(cat) != "nan")
+        if len(tidied_string) > 0:
+            if tidied_string[-1] == ";":
                 tidied_string = tidied_string[:-1]
         return tidied_string
 
@@ -134,17 +153,17 @@ def clean_data(dataframe):
             dataset_row (dataframe): one row of the dataset set
         """
         combined_tags = []
-        if str(dataset_row['OriginalTags'])!='nan':
-            combined_tags = combined_tags + str(dataset_row['OriginalTags']).split(';')
-        if str(dataset_row['ManualTags'])!='nan':
-            combined_tags = combined_tags + str(dataset_row['ManualTags']).split(';')
+        if str(dataset_row["OriginalTags"]) != "nan":
+            combined_tags = combined_tags + str(dataset_row["OriginalTags"]).split(";")
+        if str(dataset_row["ManualTags"]) != "nan":
+            combined_tags = combined_tags + str(dataset_row["ManualTags"]).split(";")
 
         combined_tags = ";".join(str(cat) for cat in set(combined_tags))
         return combined_tags
 
-    data['OriginalTags'] = data['OriginalTags'].apply(tidy_categories)
-    data['ManualTags'] = data['ManualTags'].apply(tidy_categories)
-    data['CombinedTags'] = data.apply(lambda x: combine_categories(x),axis=1)
+    data["OriginalTags"] = data["OriginalTags"].apply(tidy_categories)
+    data["ManualTags"] = data["ManualTags"].apply(tidy_categories)
+    data["CombinedTags"] = data.apply(lambda x: combine_categories(x), axis=1)
 
     ### Creating new dataset categories for ODS
     def assign_ODScategories(categories_string):
@@ -153,26 +172,397 @@ def clean_data(dataframe):
         Args:
             categories_string (string): the dataset categories as a string
         """
-        combined_tags = categories_string.split(';')
+        combined_tags = categories_string.split(";")
 
         ### Set association between dataset tag and ODS category
-        ods_categories={
-            'Arts / Culture / History':['arts','culture','history','military','art gallery','design','fashion','museum','historic centre','conservation', 'archaeology', 'events','theatre'],
-            'Budget / Finance':['tenders', 'contracts','lgcs finance','budget','finance','payment','grants','financial year', 'council tax'],
-            'Business and Economy':['business and economy','business', 'business and trade', 'economic information', 'economic development', 'business grants', 'business awards', 'health and safety', 'trading standards', 'food safety', 'business rates', 'commercial land and property' 'commercial waste', 'pollution', 'farming', 'forestry', 'crofting', 'countryside', 'farming', 'emergency planning', 'health and safety', 'trading standards', 'health and safety at work', 'regeneration', 'shopping', 'shopping centres', 'markets', 'tenders', 'contracts', 'city centre management', 'town centre management','economy','economic','economic activity','economic development','deprivation','scottish index of multiple deprivation','simd','business','estimated population','population','labour force'],
-            'Council and Government':['council buildings','community development','council and government','council', 'councils', 'council tax', 'benefits', 'council grants', 'grants', 'council departments', 'data protection', 'FOI', 'freedom of information', 'council housing', 'politicians', 'MPs', 'MSPs', 'councillors', 'elected members', 'wards', 'constituencies', 'boundaries', 'council minutes', 'council agendas', 'council plans', 'council policies'],
-            'Education':['primary schools','lgcs education & skills','education','eductional','library','school meals','schools','school', 'nurseries', 'playgroups',],
-            'Elections / Politics':['community councils','political','polling places','elections','politics','elecorate','election','electoral','electorate','local authority','council area','democracy','polling','lgcs democracy','democracy and governance','local government', 'councillor', 'councillors','community council'],
-            'Food and Environment':['food','school meals','allotment','public toilets','air','tree','vacant and derelict land supply','landscape','nature','rights of way','tree preservation order','preservation','land','contaminated','green', 'belt','employment land audit','environment','forest woodland strategy','waste','recycling','lgcs waste management','water-network', 'grafitti', 'street occupations', 'regeneration','vandalism','street cleansing', 'litter', 'toilets', 'drains','flytipping', 'flyposting','pollution', 'air quality', 'household waste', 'commercial waste'],
-            'Health and Social Care':['public toilets','contraception', 'implant','cervical','iud','ius','pis','prescribing','elderly','screening','screening programme','cancer','breast feeding','defibrillators','wards','alcohol and drug partnership', 'care homes', 'waiting times', 'drugs', 'substance use', 'pregnancy', 'induced abortion','therapeutic abortion','termination', 'abortion','co-dependency','sexual health', 'outpatient','waiting list', 'stage of treatment', 'daycase','inpatient', 'alcohol','waiting time','treatment','community wellbeing and social environment','health','human services', 'covid-19','covid','hospital','health board', 'health and social care partnership','medicine','health and social care','health and fitness','nhs24','hospital admissions','hospital mortality', 'mental health', 'pharmacy', 'GP', 'surgery','fostering','adoption', 'social work', 'asylum', 'immigration', 'citizenship', 'carers'],
-            'Housing and Estates':['buildings','housing data supply 2020','multiple occupation', 'housing', 'sheltered housing', 'adaptations', 'repairs', 'council housing', 'landlord', 'landlord registration', 'rent arrears', 'parking', 'garages', 'homelessness', 'temporary accommodation', 'rent', 'tenancy', 'housing advice', 'housing associations', 'housing advice', 'housing repairs', 'lettings','real estate','land records','land-cover','woodland','dwellings','burial grounds','cemeteries','property','vacant and derelict land','scottish vacant and derelict land','allotment'],
-            'Law and Licensing':['law', 'licensing', 'regulation', 'regulations', 'licence', 'licenses', 'permit', 'permits', 'police', 'court', 'courts', 'tribunal', 'tribunals'],
-            'Parks / Recreation':['parks','recreation','woodland','parks and open spaces'],
-            'Planning and Development':['buildings','vacant and derelict land supply','core paths. adopted', 'employment land audit','built environment','planning','zoning','council area','address','addresses','city development plan','boundaries','post-code','dwellings','planning permission','postcode-units','housing','property', 'building control', 'conservation'],
-            'Public Safety':['emergency planning','public safety','crime and justice','lgcs community safety','street lighting','community safety','cctv','road safety'],
-            'Sport and Leisure':['sport', 'sports', 'sports facilities',' sports activities','countryside', 'wildlife', 'leisure', 'leisure clubs', 'clubs', 'groups', 'societies', 'libraries', 'archives', 'local history', 'heritage', 'museums', 'galleries', 'parks', 'gardens', 'open spaces', 'sports', 'sports clubs', 'leisure centres'],
-            'Tourism':['public toilets','tourism','tourist','attractions','accomodation', 'historic buildings','tourist routes', 'cafes','restaurants', 'hotels','hotel'],
-            'Transportation':['core paths. adopted','lgcs transport infrastructure','transportation','mobility','pedestrian','walking','walk','cycle','cycling','parking','car','bus','tram','train','taxi','transport','electric vehicle','electric vehicle charging points','transport / mobility','active travel','road safety','roads', 'community transport', 'road works', 'road closures','speed limits', 'port', 'harbour']
+        ods_categories = {
+            "Arts / Culture / History": [
+                "arts",
+                "culture",
+                "history",
+                "military",
+                "art gallery",
+                "design",
+                "fashion",
+                "museum",
+                "historic centre",
+                "conservation",
+                "archaeology",
+                "events",
+                "theatre",
+            ],
+            "Budget / Finance": [
+                "tenders",
+                "contracts",
+                "lgcs finance",
+                "budget",
+                "finance",
+                "payment",
+                "grants",
+                "financial year",
+                "council tax",
+            ],
+            "Business and Economy": [
+                "business and economy",
+                "business",
+                "business and trade",
+                "economic information",
+                "economic development",
+                "business grants",
+                "business awards",
+                "health and safety",
+                "trading standards",
+                "food safety",
+                "business rates",
+                "commercial land and property" "commercial waste",
+                "pollution",
+                "farming",
+                "forestry",
+                "crofting",
+                "countryside",
+                "farming",
+                "emergency planning",
+                "health and safety",
+                "trading standards",
+                "health and safety at work",
+                "regeneration",
+                "shopping",
+                "shopping centres",
+                "markets",
+                "tenders",
+                "contracts",
+                "city centre management",
+                "town centre management",
+                "economy",
+                "economic",
+                "economic activity",
+                "economic development",
+                "deprivation",
+                "scottish index of multiple deprivation",
+                "simd",
+                "business",
+                "estimated population",
+                "population",
+                "labour force",
+            ],
+            "Council and Government": [
+                "council buildings",
+                "community development",
+                "council and government",
+                "council",
+                "councils",
+                "council tax",
+                "benefits",
+                "council grants",
+                "grants",
+                "council departments",
+                "data protection",
+                "FOI",
+                "freedom of information",
+                "council housing",
+                "politicians",
+                "MPs",
+                "MSPs",
+                "councillors",
+                "elected members",
+                "wards",
+                "constituencies",
+                "boundaries",
+                "council minutes",
+                "council agendas",
+                "council plans",
+                "council policies",
+            ],
+            "Education": [
+                "primary schools",
+                "lgcs education & skills",
+                "education",
+                "eductional",
+                "library",
+                "school meals",
+                "schools",
+                "school",
+                "nurseries",
+                "playgroups",
+            ],
+            "Elections / Politics": [
+                "community councils",
+                "political",
+                "polling places",
+                "elections",
+                "politics",
+                "elecorate",
+                "election",
+                "electoral",
+                "electorate",
+                "local authority",
+                "council area",
+                "democracy",
+                "polling",
+                "lgcs democracy",
+                "democracy and governance",
+                "local government",
+                "councillor",
+                "councillors",
+                "community council",
+            ],
+            "Food and Environment": [
+                "food",
+                "school meals",
+                "allotment",
+                "public toilets",
+                "air",
+                "tree",
+                "vacant and derelict land supply",
+                "landscape",
+                "nature",
+                "rights of way",
+                "tree preservation order",
+                "preservation",
+                "land",
+                "contaminated",
+                "green",
+                "belt",
+                "employment land audit",
+                "environment",
+                "forest woodland strategy",
+                "waste",
+                "recycling",
+                "lgcs waste management",
+                "water-network",
+                "grafitti",
+                "street occupations",
+                "regeneration",
+                "vandalism",
+                "street cleansing",
+                "litter",
+                "toilets",
+                "drains",
+                "flytipping",
+                "flyposting",
+                "pollution",
+                "air quality",
+                "household waste",
+                "commercial waste",
+            ],
+            "Health and Social Care": [
+                "public toilets",
+                "contraception",
+                "implant",
+                "cervical",
+                "iud",
+                "ius",
+                "pis",
+                "prescribing",
+                "elderly",
+                "screening",
+                "screening programme",
+                "cancer",
+                "breast feeding",
+                "defibrillators",
+                "wards",
+                "alcohol and drug partnership",
+                "care homes",
+                "waiting times",
+                "drugs",
+                "substance use",
+                "pregnancy",
+                "induced abortion",
+                "therapeutic abortion",
+                "termination",
+                "abortion",
+                "co-dependency",
+                "sexual health",
+                "outpatient",
+                "waiting list",
+                "stage of treatment",
+                "daycase",
+                "inpatient",
+                "alcohol",
+                "waiting time",
+                "treatment",
+                "community wellbeing and social environment",
+                "health",
+                "human services",
+                "covid-19",
+                "covid",
+                "hospital",
+                "health board",
+                "health and social care partnership",
+                "medicine",
+                "health and social care",
+                "health and fitness",
+                "nhs24",
+                "hospital admissions",
+                "hospital mortality",
+                "mental health",
+                "pharmacy",
+                "GP",
+                "surgery",
+                "fostering",
+                "adoption",
+                "social work",
+                "asylum",
+                "immigration",
+                "citizenship",
+                "carers",
+            ],
+            "Housing and Estates": [
+                "buildings",
+                "housing data supply 2020",
+                "multiple occupation",
+                "housing",
+                "sheltered housing",
+                "adaptations",
+                "repairs",
+                "council housing",
+                "landlord",
+                "landlord registration",
+                "rent arrears",
+                "parking",
+                "garages",
+                "homelessness",
+                "temporary accommodation",
+                "rent",
+                "tenancy",
+                "housing advice",
+                "housing associations",
+                "housing advice",
+                "housing repairs",
+                "lettings",
+                "real estate",
+                "land records",
+                "land-cover",
+                "woodland",
+                "dwellings",
+                "burial grounds",
+                "cemeteries",
+                "property",
+                "vacant and derelict land",
+                "scottish vacant and derelict land",
+                "allotment",
+            ],
+            "Law and Licensing": [
+                "law",
+                "licensing",
+                "regulation",
+                "regulations",
+                "licence",
+                "licenses",
+                "permit",
+                "permits",
+                "police",
+                "court",
+                "courts",
+                "tribunal",
+                "tribunals",
+            ],
+            "Parks / Recreation": [
+                "parks",
+                "recreation",
+                "woodland",
+                "parks and open spaces",
+            ],
+            "Planning and Development": [
+                "buildings",
+                "vacant and derelict land supply",
+                "core paths. adopted",
+                "employment land audit",
+                "built environment",
+                "planning",
+                "zoning",
+                "council area",
+                "address",
+                "addresses",
+                "city development plan",
+                "boundaries",
+                "post-code",
+                "dwellings",
+                "planning permission",
+                "postcode-units",
+                "housing",
+                "property",
+                "building control",
+                "conservation",
+            ],
+            "Public Safety": [
+                "emergency planning",
+                "public safety",
+                "crime and justice",
+                "lgcs community safety",
+                "street lighting",
+                "community safety",
+                "cctv",
+                "road safety",
+            ],
+            "Sport and Leisure": [
+                "sport",
+                "sports",
+                "sports facilities",
+                " sports activities",
+                "countryside",
+                "wildlife",
+                "leisure",
+                "leisure clubs",
+                "clubs",
+                "groups",
+                "societies",
+                "libraries",
+                "archives",
+                "local history",
+                "heritage",
+                "museums",
+                "galleries",
+                "parks",
+                "gardens",
+                "open spaces",
+                "sports",
+                "sports clubs",
+                "leisure centres",
+            ],
+            "Tourism": [
+                "public toilets",
+                "tourism",
+                "tourist",
+                "attractions",
+                "accomodation",
+                "historic buildings",
+                "tourist routes",
+                "cafes",
+                "restaurants",
+                "hotels",
+                "hotel",
+            ],
+            "Transportation": [
+                "core paths. adopted",
+                "lgcs transport infrastructure",
+                "transportation",
+                "mobility",
+                "pedestrian",
+                "walking",
+                "walk",
+                "cycle",
+                "cycling",
+                "parking",
+                "car",
+                "bus",
+                "tram",
+                "train",
+                "taxi",
+                "transport",
+                "electric vehicle",
+                "electric vehicle charging points",
+                "transport / mobility",
+                "active travel",
+                "road safety",
+                "roads",
+                "community transport",
+                "road works",
+                "road closures",
+                "speed limits",
+                "port",
+                "harbour",
+            ],
         }
 
         ### Return ODS if tag is a match
@@ -184,7 +574,7 @@ def clean_data(dataframe):
 
         ### If no match, assign "Uncategorised". Tidy list of ODS categories into string.
         if len(applied_category) == 0:
-            applied_category = ['Uncategorised']
+            applied_category = ["Uncategorised"]
 
         applied_category = ";".join(str(cat) for cat in set(applied_category))
         applied_category
@@ -192,53 +582,55 @@ def clean_data(dataframe):
         return applied_category
 
     ### Apply ODS categorisation
-    data['ODSCategories'] = data['CombinedTags'].apply(assign_ODScategories)
-
+    data["ODSCategories"] = data["CombinedTags"].apply(assign_ODScategories)
 
     ### Tidy licence names
     def tidy_licence(licence_name):
-        """ Temporary licence conversion to match export2jkan -- FOR ANALYTICS ONLY, will discard in 2022Q2 Milestone
+        """Temporary licence conversion to match export2jkan -- FOR ANALYTICS ONLY, will discard in 2022Q2 Milestone
         Returns:
             string: a tidied licence name
         """
         known_licences = {
-            'https://creativecommons.org/licenses/by-sa/3.0/': 'Creative Commons Attribution Share-Alike 3.0',
-            'Creative Commons Attribution 4.0': 'Creative Commons Attribution 4.0 International',
-            'https://creativecommons.org/licenses/by/4.0': 'Creative Commons Attribution 4.0 International',
-            'https://creativecommons.org/licenses/by/4.0/': 'Creative Commons Attribution 4.0 International',
-            'https://creativecommons.org/licenses/by/4.0/legalcode': 'Creative Commons Attribution 4.0 International',
-            'CC BY 4.0': 'Creative Commons Attribution 4.0 International',
-            'CC-BY 4.0': 'Creative Commons Attribution 4.0 International',
-            'OGL3': 'Open Government Licence v3.0',
-            'Open Government Licence 3.0 (United Kingdom)': 'Open Government Licence v3.0',
-            'UK Open Government Licence (OGL)': 'Open Government Licence v3.0',
-            'uk-ogl': 'Open Government Licence v3.0',
-            'Open Data Commons Open Database License 1.0': 'Open Data Commons Open Database License 1.0',
-            'http://opendatacommons.org/licenses/odbl/1-0/': 'Open Data Commons Open Database License 1.0',
-            'http://www.nationalarchives.gov.uk/doc/open-government-licence/version/2/': 'Open Government Licence v2.0',
-            'http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/': 'Open Government Licence v3.0',
-            'https://creativecommons.org/publicdomain/mark/1.0/': 'Public Domain',
-            'Public Domain Mark 1.0': 'Public Domain',
-            'Public Domain': 'Public Domain',
-            'Public domain': 'Public Domain',
-            'CC0': 'Creative Commons CC0',
-            'CCO': 'Creative Commons CC0',
-            'https://creativecommons.org/share-your-work/public-domain/cc0': 'Creative Commons CC0',
-            'https://rightsstatements.org/page/NoC-NC/1.0/': 'Non-Commercial Use Only',
+            "https://creativecommons.org/licenses/by-sa/3.0/": "Creative Commons Attribution Share-Alike 3.0",
+            "Creative Commons Attribution 4.0": "Creative Commons Attribution 4.0 International",
+            "https://creativecommons.org/licenses/by/4.0": "Creative Commons Attribution 4.0 International",
+            "https://creativecommons.org/licenses/by/4.0/": "Creative Commons Attribution 4.0 International",
+            "https://creativecommons.org/licenses/by/4.0/legalcode": "Creative Commons Attribution 4.0 International",
+            "CC BY 4.0": "Creative Commons Attribution 4.0 International",
+            "CC-BY 4.0": "Creative Commons Attribution 4.0 International",
+            "OGL3": "Open Government Licence v3.0",
+            "Open Government Licence 3.0 (United Kingdom)": "Open Government Licence v3.0",
+            "UK Open Government Licence (OGL)": "Open Government Licence v3.0",
+            "uk-ogl": "Open Government Licence v3.0",
+            "Open Data Commons Open Database License 1.0": "Open Data Commons Open Database License 1.0",
+            "http://opendatacommons.org/licenses/odbl/1-0/": "Open Data Commons Open Database License 1.0",
+            "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/2/": "Open Government Licence v2.0",
+            "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/": "Open Government Licence v3.0",
+            "https://creativecommons.org/publicdomain/mark/1.0/": "Public Domain",
+            "Public Domain Mark 1.0": "Public Domain",
+            "Public Domain": "Public Domain",
+            "Public domain": "Public Domain",
+            "CC0": "Creative Commons CC0",
+            "CCO": "Creative Commons CC0",
+            "https://creativecommons.org/share-your-work/public-domain/cc0": "Creative Commons CC0",
+            "https://rightsstatements.org/page/NoC-NC/1.0/": "Non-Commercial Use Only",
         }
         if licence_name in known_licences:
             tidied_licence = known_licences[licence_name]
-        elif str(licence_name) == "nan" or str(licence_name) == "No Known Copyright" or str(
-                licence_name) == "http://rightsstatements.org/vocab/NKC/1.0/":
+        elif (
+            str(licence_name) == "nan"
+            or str(licence_name) == "No Known Copyright"
+            or str(licence_name) == "http://rightsstatements.org/vocab/NKC/1.0/"
+        ):
             tidied_licence = "No licence"
         else:
             tidied_licence = "Custom licence: " + str(licence_name)
         return tidied_licence
 
-    data['License'] = data['License'].apply(tidy_licence)
+    data["License"] = data["License"].apply(tidy_licence)
+
+    return data
 
 
-    return data 
-
-if __name__=="__main__":
+if __name__ == "__main__":
     merge_data()

--- a/processor.py
+++ b/processor.py
@@ -8,17 +8,30 @@ class Processor:
     # Type should be one of the following: 'dcat', 'arcgis', 'usmart'
     def __init__(self, type):
         self.type = type
-        self.header = ["Title", "Owner", "PageURL", "AssetURL", "DateCreated", "DateUpdated", "FileSize",
-                       "FileSizeUnit", "FileType", "NumRecords", "OriginalTags", "ManualTags", "License",
-                       "Description"]
+        self.header = [
+            "Title",
+            "Owner",
+            "PageURL",
+            "AssetURL",
+            "DateCreated",
+            "DateUpdated",
+            "FileSize",
+            "FileSizeUnit",
+            "FileType",
+            "NumRecords",
+            "OriginalTags",
+            "ManualTags",
+            "License",
+            "Description",
+        ]
         self.urls = {}
 
     def get_urls(self):
-        with open('sources.csv', 'r') as file:
+        with open("sources.csv", "r") as file:
             csv_file = csv.DictReader(file)
             for row in csv_file:
-                if row['Processor'] == self.type:
-                    self.urls[row['Name']] = row['Source URL']
+                if row["Processor"] == self.type:
+                    self.urls[row["Name"]] = row["Source URL"]
 
     def get_json(self, url):
         req = request.Request(url)
@@ -27,24 +40,29 @@ class Processor:
     def get_license(self, dataset):
         try:
             # Known Licenses info
-            allLicenses = ['http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/',
-            'http://www.nationalarchives.gov.uk/doc/open-government-licence/version/2/',
-            'http://opendatacommons.org/licenses/odbl/1-0/',
-            'Open Data Commons Open Database License 1.0',
-            'uk-ogl', 'UK Open Government Licence (OGL)',
-            'Open Government Licence 3.0 (United Kingdom)',
-            'OGL3', 'https://creativecommons.org/licenses/by/4.0/legalcode',
-            'Creative Commons Attribution 4.0', 'https://creativecommons.org/licenses/by-sa/3.0/'];
+            allLicenses = [
+                "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
+                "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/2/",
+                "http://opendatacommons.org/licenses/odbl/1-0/",
+                "Open Data Commons Open Database License 1.0",
+                "uk-ogl",
+                "UK Open Government Licence (OGL)",
+                "Open Government Licence 3.0 (United Kingdom)",
+                "OGL3",
+                "https://creativecommons.org/licenses/by/4.0/legalcode",
+                "Creative Commons Attribution 4.0",
+                "https://creativecommons.org/licenses/by-sa/3.0/",
+            ]
 
             # Return License info, If License 'url' key available
-            if('url' in dataset['attributes']['structuredLicense']):
-                return dataset['attributes']['structuredLicense']['url']
+            if "url" in dataset["attributes"]["structuredLicense"]:
+                return dataset["attributes"]["structuredLicense"]["url"]
             # Check for License in 'text' key and return the license info, if license 'url' key not available
-            elif('text' in dataset['attributes']['structuredLicense']):
+            elif "text" in dataset["attributes"]["structuredLicense"]:
                 for license in allLicenses:
-                    if(license in dataset['attributes']['structuredLicense']['text']):
-                        return license;
-                return "";
+                    if license in dataset["attributes"]["structuredLicense"]["text"]:
+                        return license
+                return ""
             # Return '', if 'url' & 'text' key not available
             else:
                 return ""
@@ -52,12 +70,12 @@ class Processor:
             return ""
 
     def write_csv(self, fname, prepped):
-        with open(fname, 'w') as csvf:
+        with open(fname, "w") as csvf:
             w = csv.writer(csvf, quoting=csv.QUOTE_MINIMAL)
             w.writerow(self.header)
             for r in prepped:
                 if r[-1]:
-                    r[-1] = r[-1].replace('\n', ' ')
+                    r[-1] = r[-1].replace("\n", " ")
                 w.writerow(r)
 
     def get_datasets(self, owner, url, fname):
@@ -68,5 +86,4 @@ class Processor:
 
         for name, url in self.urls.items():
             print(name)
-            self.get_datasets(name, url, os.path.join(
-                'data', self.type, name+'.csv'))
+            self.get_datasets(name, url, os.path.join("data", self.type, name + ".csv"))

--- a/tags.py
+++ b/tags.py
@@ -1,28 +1,28 @@
 import json
 from urllib import request
 
+
 def get_thing(site, thing="tag"):
     try:
         with request.urlopen(f"{site}api/3/action/{thing}_list") as page:
             data = json.loads(page.read().decode())
-            return data['result']
+            return data["result"]
     except Exception as e:
         print(f"Error with {site}, {thing}:")
         print(e)
         return []
-    
-sites = {"Aberdeen City": "https://data.aberdeencity.gov.uk/",
-         "Dundee": "https://data.dundeecity.gov.uk/",
-         "Perth": "https://data.pkc.gov.uk/",
-         "Stirling": "https://data.stirling.gov.uk/",
-         # "Glasgow": "https://data.glasgow.gov.uk/",
-         
-         }
+
+
+sites = {
+    "Aberdeen City": "https://data.aberdeencity.gov.uk/",
+    "Dundee": "https://data.dundeecity.gov.uk/",
+    "Perth": "https://data.pkc.gov.uk/",
+    "Stirling": "https://data.stirling.gov.uk/",
+    # "Glasgow": "https://data.glasgow.gov.uk/",
+}
 
 # tags = {n: get_thing(site, "tag") for n, site in sites.items()}
 
 groups = {n: get_thing(site, "group") for n, site in sites.items()}
 
 print(groups)
-
-

--- a/tools/alive.py
+++ b/tools/alive.py
@@ -6,10 +6,10 @@ from urllib.error import URLError, HTTPError
 import csv
 import os
 
-GITHUB_REPO = 'OpenDataScotland/the_od_bods'
+GITHUB_REPO = "OpenDataScotland/the_od_bods"
 
-github_access_token = os.environ.get('GITHUB_ACCESS_TOKEN')
-github_user_assignee = os.environ.get('GITHUB_USER_ASSIGNEE')
+github_access_token = os.environ.get("GITHUB_ACCESS_TOKEN")
+github_user_assignee = os.environ.get("GITHUB_USER_ASSIGNEE")
 
 if github_access_token == None:
     print("GITHUB_ACCESS_TOKEN needs to be defined")
@@ -24,33 +24,33 @@ try:
     repo = git.get_repo(GITHUB_REPO)
 
     # Get the repo's 'broken link' issue label
-    issue_label = repo.get_label('broken link')
+    issue_label = repo.get_label("broken link")
 
-    open_issues = repo.get_issues(state='open', labels=[issue_label])
-    
+    open_issues = repo.get_issues(state="open", labels=[issue_label])
+
     # Get the project's 'To do' column
     projects = repo.get_projects()
     project = projects[0]
     project_columns = project.get_columns()
     to_do_column = None
     for project_column in project_columns:
-        if project_column.name == 'To do':
+        if project_column.name == "To do":
             to_do_column = project_column
             break
 
-    with open('../sources.csv', 'r') as file:
+    with open("../sources.csv", "r") as file:
         csv_file = csv.DictReader(file)
         for row in csv_file:
 
-            req = Request(
-                row['Source URL'])
+            req = Request(row["Source URL"])
             try:
                 response = urlopen(req)
             except (HTTPError, URLError) as e:
-                issue_body = '**Broken URL:** [#{}]({})\n\n'.format(
-                    row['Source URL'], row['Source URL'])
+                issue_body = "**Broken URL:** [#{}]({})\n\n".format(
+                    row["Source URL"], row["Source URL"]
+                )
                 # Create an issue on GitHub
-                issue_title = 'Broken URL for {}'.format(row['Name'])
+                issue_title = "Broken URL for {}".format(row["Name"])
 
                 # Has an issue already been raised?
                 exists = False
@@ -59,21 +59,31 @@ try:
                         exists = True
                         break
 
-                if exists == False:                
-                    new_issue = repo.create_issue(title=issue_title, assignee=github_user_assignee, body=issue_body, labels=[issue_label])
-                    to_do_column.create_card(content_id=new_issue.id, content_type='Issue')
+                if exists == False:
+                    new_issue = repo.create_issue(
+                        title=issue_title,
+                        assignee=github_user_assignee,
+                        body=issue_body,
+                        labels=[issue_label],
+                    )
+                    to_do_column.create_card(
+                        content_id=new_issue.id, content_type="Issue"
+                    )
                     print(new_issue)
             else:
-                issue_body = '**Broken URL:** [#{}]({})\n\n'.format(
-                    row['Source URL'], row['Source URL'])
+                issue_body = "**Broken URL:** [#{}]({})\n\n".format(
+                    row["Source URL"], row["Source URL"]
+                )
                 # Close an issue if open for previously broken URL
-                issue_title = 'Broken URL for {}'.format(row['Name'])
+                issue_title = "Broken URL for {}".format(row["Name"])
 
                 for issue in open_issues:
                     if issue.title == issue_title:
-                        issue.create_comment("Automatically closed due to URL now working.")
-                        issue.edit(state='closed')
+                        issue.create_comment(
+                            "Automatically closed due to URL now working."
+                        )
+                        issue.edit(state="closed")
                         break
 
 except GithubException as err:
-    print('Github: Connect: error {}', format(err.data))
+    print("Github: Connect: error {}", format(err.data))

--- a/usmart.py
+++ b/usmart.py
@@ -1,8 +1,9 @@
 from processor import Processor
 
+
 class ProcessorUSMART(Processor):
     def __init__(self):
-        super().__init__(type='USMART')
+        super().__init__(type="USMART")
 
     def get_datasets(self, owner, start_url, fname):
         data = processor.get_json(start_url)
@@ -10,7 +11,6 @@ class ProcessorUSMART(Processor):
         print("Number of datasets: ", str(len(datasets)))
 
         prepped = []
-
 
         for dataset in datasets:
             Title = dataset["title"]
@@ -26,16 +26,19 @@ class ProcessorUSMART(Processor):
             DateCreated = dataset["createdAt"]
             DateUpdated = dataset["modified"]
             Description = '"' + dataset["description"] + '"'
-            if dataset["licence"] == "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/":
+            if (
+                dataset["licence"]
+                == "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+            ):
                 Licence = "OGL3"
             else:
                 Licence = dataset["licence"]
             OriginalTags = []
-            for theme in dataset['theme']:
+            for theme in dataset["theme"]:
                 OriginalTags.append(theme)
             ManualTags = []
-            if 'keyword' in dataset:
-                for kw in dataset['keyword']:
+            if "keyword" in dataset:
+                for kw in dataset["keyword"]:
                     ManualTags.append(kw)
             else:
                 ManualTags.append(" ")
@@ -54,11 +57,13 @@ class ProcessorUSMART(Processor):
                     " ".join(OriginalTags),
                     " ".join(ManualTags),
                     Licence,
-                    Description]
+                    Description,
+                ]
 
                 prepped.append(line)
 
         processor.write_csv(fname, prepped)
+
 
 processor = ProcessorUSMART()
 processor.process()

--- a/web-scrapers/aberdeenshire_council_scraper.py
+++ b/web-scrapers/aberdeenshire_council_scraper.py
@@ -6,7 +6,7 @@ import math
 
 # https://stackoverflow.com/a/14822210/13940304
 def convert_size(size_bytes):
-    """ Takes a size in bytes and convert units
+    """Takes a size in bytes and convert units
 
     Args:
         size_bytes (int): raw size in bytes
@@ -21,6 +21,7 @@ def convert_size(size_bytes):
     p = math.pow(1024, i)
     s = round(size_bytes / p, 2)
     return ("%s" % (s), size_name[i])
+
 
 def get_last_updated(string):
     matches = datefinder.find_dates(string)
@@ -37,100 +38,133 @@ def get_feeds(soup):
         list: list containing all feed dictionaries
     """
 
-    #Get table and rows
-    table = soup.find('table')
-    rows = table.find_all('tr')[1:]
+    # Get table and rows
+    table = soup.find("table")
+    rows = table.find_all("tr")[1:]
 
     feeds = []
 
     # get title and files associated to the feed
     for row in rows:
-        tds = row.find_all('td')
+        tds = row.find_all("td")
         feed = {}
         # Add title and files key
         title = tds[0].get_text()
         print(title)
-        feed['title'] = title
-        feed['files'] = {}
+        feed["title"] = title
+        feed["files"] = {}
         # Add files with their links, last updated and filesize.
-        files = [a_tag for a_tag in tds[1].find_all('a', href=True)]
+        files = [a_tag for a_tag in tds[1].find_all("a", href=True)]
         for anchor in files:
-            link = anchor.get('href')
-            if link.endswith('.kmz') or link.endswith('.csv') or link.endswith('.zip'):
-                filename = link.rsplit('/', 1)[-1]
+            link = anchor.get("href")
+            if link.endswith(".kmz") or link.endswith(".csv") or link.endswith(".zip"):
+                filename = link.rsplit("/", 1)[-1]
                 # get last updated
                 last_updated = get_last_updated(anchor.text)
                 # get size of file
                 # try:
                 #     filesize = urlopen(link).length
-                # except Exception as e: 
+                # except Exception as e:
                 #     print("Couldn't get file size!")
                 #     print(e)
-                #     filesize = 0 
+                #     filesize = 0
                 filesize = 0
                 formatted_fs, unit = convert_size(filesize)
 
-                feed['files'][filename] = {'link': link, 'filesize': {'value':formatted_fs, 'unit': unit}, 'last-updated': last_updated, 'filetype': filename[-3:].upper()}
+                feed["files"][filename] = {
+                    "link": link,
+                    "filesize": {"value": formatted_fs, "unit": unit},
+                    "last-updated": last_updated,
+                    "filetype": filename[-3:].upper(),
+                }
         feeds.append(feed)
     return feeds
 
+
 def parse_feeds(feeds):
-    """ Process feeds to be ready for csv ouput """
+    """Process feeds to be ready for csv ouput"""
     proc_feeds = []
     for feed in feeds:
-        for datafile in feed['files'].keys():
+        for datafile in feed["files"].keys():
             formatted_feed = []
-            formatted_feed.append(feed['title'])
-            formatted_feed.append('Aberdeenshire Council')
-            formatted_feed.append('https://www.aberdeenshire.gov.uk/online/open-data/')
-            formatted_feed.append(feed['files'][datafile]['link'])
-            formatted_feed.append('NULL')
-            formatted_feed.append(feed['files'][datafile]['last-updated'])
-            formatted_feed.append(feed['files'][datafile]['filesize']['value'])
-            formatted_feed.append(feed['files'][datafile]['filesize']['unit'])
-            formatted_feed.append(feed['files'][datafile]['filetype'])
-            formatted_feed.append('NULL')
-            formatted_feed.append('NULL')
-            #hack to create categories
-            if 'school' in feed['title'].lower():
-                formatted_feed.append('education')
-            elif 'burial' in feed['title'].lower():
-                formatted_feed.append('burial grounds')
-            elif 'car parks' or 'cycle' or 'grit' or 'harbours' or 'core paths' in title:
-                formatted_feed.append('transport')
-            elif 'polling'in feed['title'].lower():
-                formatted_feed.append('elections')
-            elif 'applications' or 'development' or 'green belt' or 'land audit' in feed['title'].lower():
-                formatted_feed.append('planning')
-            elif 'recycling' in feed['title'].lower():
-                formatted_feed.append('recycling')
-            elif 'toiliets' in feed['title'].lower():
-                formatted_feed.append('toilets')
-            elif 'museums' in feed['title'].lower():
-                formatted_feed.append('museum')
-            elif 'nature' in feed['title'].lower():
-                formatted_feed.append('nature')
-            elif 'leisure' in feed['title'].lower():
-                formatted_feed.append ('leisure')
-            elif 'cooling tower' in feed['title'].lower():
-                formatted_feed.append('health and safety')
-            elif 'contracts register' in feed['title'].lower():
-                formatted_feed.append('contracts')
-            elif 'committee areas' or 'community councils' or 'offices open' in feed['title'].lower():
-                formatted_feed.append('council and government')
+            formatted_feed.append(feed["title"])
+            formatted_feed.append("Aberdeenshire Council")
+            formatted_feed.append("https://www.aberdeenshire.gov.uk/online/open-data/")
+            formatted_feed.append(feed["files"][datafile]["link"])
+            formatted_feed.append("NULL")
+            formatted_feed.append(feed["files"][datafile]["last-updated"])
+            formatted_feed.append(feed["files"][datafile]["filesize"]["value"])
+            formatted_feed.append(feed["files"][datafile]["filesize"]["unit"])
+            formatted_feed.append(feed["files"][datafile]["filetype"])
+            formatted_feed.append("NULL")
+            formatted_feed.append("NULL")
+            # hack to create categories
+            if "school" in feed["title"].lower():
+                formatted_feed.append("education")
+            elif "burial" in feed["title"].lower():
+                formatted_feed.append("burial grounds")
+            elif (
+                "car parks" or "cycle" or "grit" or "harbours" or "core paths" in title
+            ):
+                formatted_feed.append("transport")
+            elif "polling" in feed["title"].lower():
+                formatted_feed.append("elections")
+            elif (
+                "applications"
+                or "development"
+                or "green belt"
+                or "land audit" in feed["title"].lower()
+            ):
+                formatted_feed.append("planning")
+            elif "recycling" in feed["title"].lower():
+                formatted_feed.append("recycling")
+            elif "toiliets" in feed["title"].lower():
+                formatted_feed.append("toilets")
+            elif "museums" in feed["title"].lower():
+                formatted_feed.append("museum")
+            elif "nature" in feed["title"].lower():
+                formatted_feed.append("nature")
+            elif "leisure" in feed["title"].lower():
+                formatted_feed.append("leisure")
+            elif "cooling tower" in feed["title"].lower():
+                formatted_feed.append("health and safety")
+            elif "contracts register" in feed["title"].lower():
+                formatted_feed.append("contracts")
+            elif (
+                "committee areas"
+                or "community councils"
+                or "offices open" in feed["title"].lower()
+            ):
+                formatted_feed.append("council and government")
             else:
-                formatted_feed.append('council and government')
-            formatted_feed.append('Open Government')
-            formatted_feed.append('NULL')
+                formatted_feed.append("council and government")
+            formatted_feed.append("Open Government")
+            formatted_feed.append("NULL")
             proc_feeds.append(formatted_feed)
     return proc_feeds
 
+
 def output(parsed):
-    with open('../data/scraped-results/aberdeenshire.csv', 'w', encoding='UTF8') as f:
+    with open("../data/scraped-results/aberdeenshire.csv", "w", encoding="UTF8") as f:
         writer = csv.writer(f)
 
         # write the header
-        header = ["Title","Owner","PageURL","AssetURL","DateCreated","DateUpdated","FileSize","FileSizeUnit","FileType","NumRecords","OriginalTags","ManualTags","License","Description"]
+        header = [
+            "Title",
+            "Owner",
+            "PageURL",
+            "AssetURL",
+            "DateCreated",
+            "DateUpdated",
+            "FileSize",
+            "FileSizeUnit",
+            "FileType",
+            "NumRecords",
+            "OriginalTags",
+            "ManualTags",
+            "License",
+            "Description",
+        ]
         writer.writerow(header)
 
         # write the data
@@ -140,12 +174,15 @@ def output(parsed):
 
 if __name__ == "__main__":
     ### construct array of feed objects
-    req = Request('https://www.aberdeenshire.gov.uk/data/open-data/', headers={'User-Agent': 'Mozilla/5.0'})
+    req = Request(
+        "https://www.aberdeenshire.gov.uk/data/open-data/",
+        headers={"User-Agent": "Mozilla/5.0"},
+    )
     page = urlopen(req).read()
-    soup = BeautifulSoup(page, 'html.parser')
+    soup = BeautifulSoup(page, "html.parser")
 
     feeds = get_feeds(soup)
     parsed = parse_feeds(feeds)
-    
+
     # make csv file
     output(parsed)

--- a/web-scrapers/east_ayrshire_scraper.py
+++ b/web-scrapers/east_ayrshire_scraper.py
@@ -5,7 +5,9 @@ import math
 from bs4 import BeautifulSoup
 
 URL_COUNCIL = "https://www.east-ayrshire.gov.uk/"
-URL_PAGE = "CouncilAndGovernment/About-the-Council/Information-and-statistics/Open-Data.aspx"
+URL_PAGE = (
+    "CouncilAndGovernment/About-the-Council/Information-and-statistics/Open-Data.aspx"
+)
 
 # Global Variables
 def get_headers():
@@ -19,13 +21,14 @@ def get_headers():
         headers (Dictionary) : header values
     """
     headers = {
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': 'GET',
-        'Access-Control-Allow-Headers': 'Content-Type',
-        'Access-Control-Max-Age': '3600',
-        'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:52.0) Gecko/20100101 Firefox/52.0'
-        }
-    return headers    
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET",
+        "Access-Control-Allow-Headers": "Content-Type",
+        "Access-Control-Max-Age": "3600",
+        "User-Agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:52.0) Gecko/20100101 Firefox/52.0",
+    }
+    return headers
+
 
 def get_all_files():
     """
@@ -36,21 +39,22 @@ def get_all_files():
 
     Returns:
         headers (List) : list of csv files.
-    """ 
-    url = URL_COUNCIL+URL_PAGE 
+    """
+    url = URL_COUNCIL + URL_PAGE
     req = requests.get(url, get_headers())
-    soup = BeautifulSoup(req.content, 'html.parser')
+    soup = BeautifulSoup(req.content, "html.parser")
     list_of_a_tags = soup.find_all("a", href=True)
     list_of_files = []
     for poss in list_of_a_tags:
-        if (poss['href'].endswith('csv')):
+        if poss["href"].endswith("csv"):
             list_of_files.append(poss)
 
-    return list_of_files        
+    return list_of_files
+
 
 def csv_file_metadata(file_loc):
     """
-    Gets file size and number of record for .csv file. 
+    Gets file size and number of record for .csv file.
 
     Args:
         file_loc (String): URL for location of file on the internet
@@ -58,38 +62,41 @@ def csv_file_metadata(file_loc):
     Returns:
         number_of_records (int), total_bytes (int) : total number of records and total number of bytes of .csv files.
     """
-    text = requests.get(URL_COUNCIL+file_loc , get_headers()).text
+    text = requests.get(URL_COUNCIL + file_loc, get_headers()).text
     lines = text.splitlines()
     data = csv.reader(lines)
-    number_of_records = len(list(data))-1
+    number_of_records = len(list(data)) - 1
 
     total_bytes = -1
     for line in lines:
         bytes_on_this_line = len(line) + 1
         total_bytes += bytes_on_this_line
 
+    return number_of_records, total_bytes
 
-    return number_of_records, total_bytes    
 
 def csv_output(header, data):
     """
-    Create output csv file of the final data scrapped from website. 
+    Create output csv file of the final data scrapped from website.
 
     Args:
         header (List): A list of header items that are Strings.
-        data (List): A list of records. 
+        data (List): A list of records.
     Returns:
         NULL
-    """   
-    with open('../data/scraped-results/output_east_ayrshire.csv', 'w', encoding='UTF8') as f:
+    """
+    with open(
+        "../data/scraped-results/output_east_ayrshire.csv", "w", encoding="UTF8"
+    ) as f:
         writer = csv.writer(f)
 
-    # write the header
+        # write the header
         writer.writerow(header)
 
-    # write the data
+        # write the data
         for record in data:
             writer.writerow(record)
+
 
 # https://stackoverflow.com/a/14822210/13940304
 def convert_size(size_bytes):
@@ -100,28 +107,59 @@ def convert_size(size_bytes):
 
     Args:
         size_bytes (int): A list of header items that are Strings.
-        data (List): A list of records. 
+        data (List): A list of records.
     Returns:
         tuple (Tuple): a tuple which has the file size and the file unit
     """
     if size_bytes == 0:
-       return "0B"
+        return "0B"
     size_name = ("B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB")
     i = int(math.floor(math.log(size_bytes, 1024)))
     p = math.pow(1024, i)
     s = round(size_bytes / p, 2)
     return ("%s %s" % (s, size_name[i]), size_name[i])
 
-if __name__ == "__main__":  
+
+if __name__ == "__main__":
     # Record Headings
-    header = ["Title","Owner","PageURL","AssetURL","DateCreated","DateUpdated","FileSize","FileSizeUnit","FileType","NumRecords","OriginalTags","ManualTags","License","Description"]
+    header = [
+        "Title",
+        "Owner",
+        "PageURL",
+        "AssetURL",
+        "DateCreated",
+        "DateUpdated",
+        "FileSize",
+        "FileSizeUnit",
+        "FileType",
+        "NumRecords",
+        "OriginalTags",
+        "ManualTags",
+        "License",
+        "Description",
+    ]
     data = []
 
     list_of_files = get_all_files()
     for fi in list_of_files:
-        metadata = csv_file_metadata(fi['href'])
+        metadata = csv_file_metadata(fi["href"])
         file_size = convert_size(metadata[1])
-        output = [fi.string, "East Ayrshire Council", URL_COUNCIL+URL_PAGE, URL_COUNCIL+fi['href'], "NULL", "NULL", file_size[0], file_size[1], "CSV", metadata[0], "NULL", "Education", "Open Government Licence 3.0 (United Kingdom)", "NULL"]     
+        output = [
+            fi.string,
+            "East Ayrshire Council",
+            URL_COUNCIL + URL_PAGE,
+            URL_COUNCIL + fi["href"],
+            "NULL",
+            "NULL",
+            file_size[0],
+            file_size[1],
+            "CSV",
+            metadata[0],
+            "NULL",
+            "Education",
+            "Open Government Licence 3.0 (United Kingdom)",
+            "NULL",
+        ]
         data.append(output)
 
     csv_output(header, data)

--- a/web-scrapers/moray_council_scraper.py
+++ b/web-scrapers/moray_council_scraper.py
@@ -8,6 +8,7 @@ from bs4 import BeautifulSoup
 URL_COUNCIL = "http://www.moray.gov.uk/"
 URL_PAGE = "moray_standard/page_110140.html"
 
+
 def get_headers():
     """
     Gets headers to make a request from the URL. Optimized so website doesn't think a bot is making a request.
@@ -17,15 +18,16 @@ def get_headers():
 
     Returns:
         headers (Dictionary) : header values
-    """       
+    """
     headers = {
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': 'GET',
-        'Access-Control-Allow-Headers': 'Content-Type',
-        'Access-Control-Max-Age': '3600',
-        'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:52.0) Gecko/20100101 Firefox/52.0'
-        }
-    return headers    
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET",
+        "Access-Control-Allow-Headers": "Content-Type",
+        "Access-Control-Max-Age": "3600",
+        "User-Agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:52.0) Gecko/20100101 Firefox/52.0",
+    }
+    return headers
+
 
 def get_all_files():
     """
@@ -36,10 +38,10 @@ def get_all_files():
 
     Returns:
         headers (List) : list of titles of table, list of descriptions of table, list of csv files.
-    """ 
-    url = URL_COUNCIL+URL_PAGE
+    """
+    url = URL_COUNCIL + URL_PAGE
     req = requests.get(url, get_headers())
-    soup = BeautifulSoup(req.content, 'html.parser')
+    soup = BeautifulSoup(req.content, "html.parser")
     list_of_files = []
 
     list_of_titles = soup.select("td:nth-of-type(1)")
@@ -47,46 +49,47 @@ def get_all_files():
 
     list_of_a_tags = soup.find_all("a", href=True)
     for poss in list_of_a_tags:
-        if (poss['href'].endswith('csv')):
+        if poss["href"].endswith("csv"):
             list_of_files.append(poss)
 
-    return list_of_titles, list_of_desc, list_of_files        
+    return list_of_titles, list_of_desc, list_of_files
+
 
 def csv_file_metadata(file_loc):
     """
-    Gets file size and number of record for .csv file. 
+    Gets file size and number of record for .csv file.
 
     Args:
         file_loc (String): URL for location of file on the internet
 
     Returns:
         number_of_records (int), total_bytes (int) : total number of records and total number of bytes of .csv files.
-    """ 
-    text = requests.get(file_loc , get_headers()).text
+    """
+    text = requests.get(file_loc, get_headers()).text
     lines = text.splitlines()
     data = csv.reader(lines)
-    number_of_records = len(list(data))-1
+    number_of_records = len(list(data)) - 1
 
     total_bytes = -1
     for line in lines:
         bytes_on_this_line = len(line) + 1
         total_bytes += bytes_on_this_line
 
+    return number_of_records, total_bytes
 
-    return number_of_records, total_bytes  
 
 def csv_output(header, data):
     """
-    Create output csv file of the final data scrapped from website. 
+    Create output csv file of the final data scrapped from website.
 
     Args:
         header (List): A list of header items that are Strings.
-        data (List): A list of records. 
+        data (List): A list of records.
     Returns:
         NULL
-    """  
+    """
 
-    with open('../data/scraped-results/output_moray.csv', 'w', encoding='UTF8') as f:
+    with open("../data/scraped-results/output_moray.csv", "w", encoding="UTF8") as f:
         writer = csv.writer(f)
 
         # write the header
@@ -96,6 +99,7 @@ def csv_output(header, data):
         for record in data:
             writer.writerow(record)
 
+
 def convert_size(size_bytes):
     """
     Create human-readable way to display .csv file sizes.
@@ -104,30 +108,61 @@ def convert_size(size_bytes):
 
     Args:
         size_bytes (int): A list of header items that are Strings.
-        data (List): A list of records. 
+        data (List): A list of records.
     Returns:
         tuple (Tuple): a tuple which has the file size and the file unit
-    """ 
+    """
     if size_bytes == 0:
-       return "0B"
+        return "0B"
     size_name = ("B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB")
     i = int(math.floor(math.log(size_bytes, 1024)))
     p = math.pow(1024, i)
     s = round(size_bytes / p, 2)
     return ("%s %s" % (s, size_name[i]), size_name[i])
 
+
 if __name__ == "__main__":
     # Record Headings
-    header = ["Title","Owner","PageURL","AssetURL","DateCreated","DateUpdated","FileSize","FileSizeUnit","FileType","NumRecords","OriginalTags","ManualTags","License","Description"]
+    header = [
+        "Title",
+        "Owner",
+        "PageURL",
+        "AssetURL",
+        "DateCreated",
+        "DateUpdated",
+        "FileSize",
+        "FileSizeUnit",
+        "FileType",
+        "NumRecords",
+        "OriginalTags",
+        "ManualTags",
+        "License",
+        "Description",
+    ]
     data = []
 
     list_of_titles, list_of_desc, list_of_files = get_all_files()
 
     counter = 1
     for fi in list_of_files:
-        metadata = csv_file_metadata(fi['href'])
+        metadata = csv_file_metadata(fi["href"])
         file_size = convert_size(metadata[1])
-        output = [list_of_titles[counter].string, "Moray Council", URL_COUNCIL+URL_PAGE, fi['href'], "NULL", "NULL", file_size[0], file_size[1], "CSV", metadata[0], "NULL", list_of_titles[counter].string.replace(" ", ""), "Open Government Licence 3.0 (United Kingdom)", list_of_desc[counter].string]     
+        output = [
+            list_of_titles[counter].string,
+            "Moray Council",
+            URL_COUNCIL + URL_PAGE,
+            fi["href"],
+            "NULL",
+            "NULL",
+            file_size[0],
+            file_size[1],
+            "CSV",
+            metadata[0],
+            "NULL",
+            list_of_titles[counter].string.replace(" ", ""),
+            "Open Government Licence 3.0 (United Kingdom)",
+            list_of_desc[counter].string,
+        ]
         data.append(output)
         counter += 1
 

--- a/web-scrapers/nls_scraper.py
+++ b/web-scrapers/nls_scraper.py
@@ -19,12 +19,12 @@ def get_headers():
         headers (Dictionary) : header values
     """
     headers = {
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': 'GET',
-        'Access-Control-Allow-Headers': 'Content-Type',
-        'Access-Control-Max-Age': '3600',
-        'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:52.0) Gecko/20100101 Firefox/52.0'
-        }
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET",
+        "Access-Control-Allow-Headers": "Content-Type",
+        "Access-Control-Max-Age": "3600",
+        "User-Agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:52.0) Gecko/20100101 Firefox/52.0",
+    }
     return headers
 
 
@@ -39,7 +39,7 @@ def csv_output(header, data):
         NULL
     """
 
-    with open('../data/scraped-results/output_nls.csv', 'w', encoding='UTF8') as f:
+    with open("../data/scraped-results/output_nls.csv", "w", encoding="UTF8") as f:
         writer = csv.writer(f)
 
         # write the header
@@ -52,17 +52,19 @@ def csv_output(header, data):
 
 def fetch_category_links():
     """
-        Fetches links to data category pages from ODR_URL. It uses the dropdown menu on the 'Data' button.
+    Fetches links to data category pages from ODR_URL. It uses the dropdown menu on the 'Data' button.
 
-        Returns:
-            list_of_links (List): A list of URLs linking to the pages for each data category.
+    Returns:
+        list_of_links (List): A list of URLs linking to the pages for each data category.
     """
     initial_req = requests.get(ODR_URL, get_headers())
     initial_soup = BeautifulSoup(initial_req.text, "html.parser")
     data_button = initial_soup.find("li", id="menu-item-41")
     dropdown_list = data_button.find_all("li")
 
-    list_of_links = [dropdown_item.find("a").get("href") for dropdown_item in dropdown_list]
+    list_of_links = [
+        dropdown_item.find("a").get("href") for dropdown_item in dropdown_list
+    ]
 
     """
     list_of_links = []
@@ -72,7 +74,7 @@ def fetch_category_links():
         list_of_links.append(link)
     """
 
-    #print(list_of_links) # for logging and debugging
+    # print(list_of_links) # for logging and debugging
     return list_of_links
 
 
@@ -96,7 +98,7 @@ def fetch_data_page_urls(url: str) -> list:
         for tag in caption.find_all("a"):
             data_page_urls.append(tag.get("href"))
 
-    #print(data_page_urls) # for logging and debugging
+    # print(data_page_urls) # for logging and debugging
     return data_page_urls
 
 
@@ -123,7 +125,11 @@ def fetch_asset_url(page: BeautifulSoup) -> str:
         asseturl (str): A url to the data files of the specific dataset.
     """
     asseturl = "NULL"
-    possible_button_text = ["Download full dataset", "Download the dataset", "Download the data", ]
+    possible_button_text = [
+        "Download full dataset",
+        "Download the dataset",
+        "Download the data",
+    ]
 
     buttons = page.find_all("a", class_="wp-block-button__link no-border-radius")
     if not buttons:  # Because one collection's page uses a different button class
@@ -233,7 +239,6 @@ def fetch_num_recs(page: BeautifulSoup) -> int:
     return amount_recs
 
 
-
 def fetch_data_types(page: BeautifulSoup) -> list:
     """
     Fetches the data types of the specific dataset.
@@ -256,45 +261,47 @@ def fetch_data_types(page: BeautifulSoup) -> list:
             # print("file_type", file_type)
             lowercase_file_types = []
             for item in file_type:
-                lowercase_file_type = item.lower().strip('.()')
+                lowercase_file_type = item.lower().strip(".()")
                 lowercase_file_types.append(lowercase_file_type)
-            #print("lowercase_file_types", lowercase_file_types)
+            # print("lowercase_file_types", lowercase_file_types)
             tidied_file_type = tidy_data_type(lowercase_file_types)
             list_of_types.append(tidied_file_type)
-            list_of_types = list(set(list_of_types)) # make it a list, where each file type is listed just once
+            list_of_types = list(
+                set(list_of_types)
+            )  # make it a list, where each file type is listed just once
 
     return list_of_types
 
 
 def tidy_data_type(file_type):
-    """ Temporary data type conversion
+    """Temporary data type conversion
     Args:
         file_type (str): the data type name
     Returns:
         tidied_data_type (str): a tidied data type name
     """
-    known_data_types= {
-        'plain text': 'TXT',
-        'text': 'TXT',
-        'txt': 'TXT',
-        'csv': 'CSV',
-        'tsv': 'TSV',
-        'zip': 'ZIP',
-        'html': 'HTML',
-        'mets': 'METS XML',
-        'alto': 'ALTO XML',
-        'image': 'Image',
-        'xml': 'XML',
+    known_data_types = {
+        "plain text": "TXT",
+        "text": "TXT",
+        "txt": "TXT",
+        "csv": "CSV",
+        "tsv": "TSV",
+        "zip": "ZIP",
+        "html": "HTML",
+        "mets": "METS XML",
+        "alto": "ALTO XML",
+        "image": "Image",
+        "xml": "XML",
     }
     tidied_data_type = "NULL"
     if str(file_type) == []:
         tidied_data_type = "No file type"
     else:
         for type in file_type:
-            #print("type", type)
+            # print("type", type)
             if type in known_data_types:
                 tidied_data_type = known_data_types[type]
-        #else:
+        # else:
         #    tidied_data_type = "Custom file type: " + str(file_type)
     return tidied_data_type
 
@@ -309,45 +316,57 @@ def fetch_licences(page):
         list_of_licences (List): A list of licences.
     """
     if not (figures := page.find_all("figure", class_="wp-block-image is-resized")):
-        if not (figures := page.find_all("figure", class_="wp-block-image size-medium is-resized")):
-            if not (figures := page.find_all("figure", class_="wp-block-image size-large is-resized")):
+        if not (
+            figures := page.find_all(
+                "figure", class_="wp-block-image size-medium is-resized"
+            )
+        ):
+            if not (
+                figures := page.find_all(
+                    "figure", class_="wp-block-image size-large is-resized"
+                )
+            ):
                 return []
     return [tidy_licence(f.find("a").get("href")) for f in figures]
 
 
 def tidy_licence(licence_name):
-    """ Temporary licence conversion to match export2jkan -- FOR ANALYTICS ONLY, will discard in 2022Q2 Milestone
+    """Temporary licence conversion to match export2jkan -- FOR ANALYTICS ONLY, will discard in 2022Q2 Milestone
     Returns:
         string: a tidied licence name
     """
-    known_licences= {
-        'https://creativecommons.org/licenses/by-sa/3.0/': 'Creative Commons Attribution Share-Alike 3.0',
-        'Creative Commons Attribution 4.0':'Creative Commons Attribution 4.0 International',
-        'https://creativecommons.org/licenses/by/4.0':'Creative Commons Attribution 4.0 International',
-        'https://creativecommons.org/licenses/by/4.0/':'Creative Commons Attribution 4.0 International',
-        'https://creativecommons.org/licenses/by/4.0/legalcode':'Creative Commons Attribution 4.0 International',
-        'CC BY 4.0':'Creative Commons Attribution 4.0 International',
-        'CC-BY 4.0': 'Creative Commons Attribution 4.0 International',
-        'OGL3':'Open Government Licence v3.0',
-        'Open Government Licence 3.0 (United Kingdom)':'Open Government Licence v3.0',
-        'UK Open Government Licence (OGL)':'Open Government Licence v3.0',
-        'uk-ogl':'Open Government Licence v3.0',
-        'Open Data Commons Open Database License 1.0':'Open Data Commons Open Database License 1.0',
-        'http://opendatacommons.org/licenses/odbl/1-0/':'Open Data Commons Open Database License 1.0',
-        'http://www.nationalarchives.gov.uk/doc/open-government-licence/version/2/':'Open Government Licence v2.0',
-        'http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/':'Open Government Licence v3.0',
-        'https://creativecommons.org/publicdomain/mark/1.0/':'Public Domain',
-        'Public Domain Mark 1.0':'Public Domain',
-        'Public Domain': 'Public Domain',
-        'Public domain': 'Public Domain',
-        'CC0':'Creative Commons CC0',
-        'CCO':'Creative Commons CC0',
-        'https://creativecommons.org/share-your-work/public-domain/cc0':'Creative Commons CC0',
-        'https://rightsstatements.org/page/NoC-NC/1.0/':'Non-Commercial Use Only',
+    known_licences = {
+        "https://creativecommons.org/licenses/by-sa/3.0/": "Creative Commons Attribution Share-Alike 3.0",
+        "Creative Commons Attribution 4.0": "Creative Commons Attribution 4.0 International",
+        "https://creativecommons.org/licenses/by/4.0": "Creative Commons Attribution 4.0 International",
+        "https://creativecommons.org/licenses/by/4.0/": "Creative Commons Attribution 4.0 International",
+        "https://creativecommons.org/licenses/by/4.0/legalcode": "Creative Commons Attribution 4.0 International",
+        "CC BY 4.0": "Creative Commons Attribution 4.0 International",
+        "CC-BY 4.0": "Creative Commons Attribution 4.0 International",
+        "OGL3": "Open Government Licence v3.0",
+        "Open Government Licence 3.0 (United Kingdom)": "Open Government Licence v3.0",
+        "UK Open Government Licence (OGL)": "Open Government Licence v3.0",
+        "uk-ogl": "Open Government Licence v3.0",
+        "Open Data Commons Open Database License 1.0": "Open Data Commons Open Database License 1.0",
+        "http://opendatacommons.org/licenses/odbl/1-0/": "Open Data Commons Open Database License 1.0",
+        "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/2/": "Open Government Licence v2.0",
+        "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/": "Open Government Licence v3.0",
+        "https://creativecommons.org/publicdomain/mark/1.0/": "Public Domain",
+        "Public Domain Mark 1.0": "Public Domain",
+        "Public Domain": "Public Domain",
+        "Public domain": "Public Domain",
+        "CC0": "Creative Commons CC0",
+        "CCO": "Creative Commons CC0",
+        "https://creativecommons.org/share-your-work/public-domain/cc0": "Creative Commons CC0",
+        "https://rightsstatements.org/page/NoC-NC/1.0/": "Non-Commercial Use Only",
     }
     if licence_name in known_licences:
         tidied_licence = known_licences[licence_name]
-    elif str(licence_name)=="nan" or str(licence_name)=="No Known Copyright" or str(licence_name) == "http://rightsstatements.org/vocab/NKC/1.0/":
+    elif (
+        str(licence_name) == "nan"
+        or str(licence_name) == "No Known Copyright"
+        or str(licence_name) == "http://rightsstatements.org/vocab/NKC/1.0/"
+    ):
         tidied_licence = "No licence"
     else:
         tidied_licence = "Custom licence: " + str(licence_name)
@@ -356,13 +375,29 @@ def tidy_licence(licence_name):
 
 if __name__ == "__main__":
     # Record Headings
-    header = ["Title", "Owner", "PageURL", "AssetURL", "DateCreated", "DateUpdated", "FileSize", "FileSizeUnit",
-              "FileType", "NumRecords", "OriginalTags", "ManualTags", "License", "Description", ]
+    header = [
+        "Title",
+        "Owner",
+        "PageURL",
+        "AssetURL",
+        "DateCreated",
+        "DateUpdated",
+        "FileSize",
+        "FileSizeUnit",
+        "FileType",
+        "NumRecords",
+        "OriginalTags",
+        "ManualTags",
+        "License",
+        "Description",
+    ]
     data = []
-    category_match = {"Digitised material collection": "digitised-collections",
-                      "Metadata collection": "metadata-collections",
-                      "Spatial data": "map-spatial-data",
-                      "Organisational data": "organisational-data"} # this code is probably not required anymore, since
+    category_match = {
+        "Digitised material collection": "digitised-collections",
+        "Metadata collection": "metadata-collections",
+        "Spatial data": "map-spatial-data",
+        "Organisational data": "organisational-data",
+    }  # this code is probably not required anymore, since
     # category_match only served to assemble the data_page_url. But I kept it for the time being, in case we want to
     # include this in the output_csv.
 
@@ -377,23 +412,23 @@ if __name__ == "__main__":
             req = requests.get(url, get_headers())
             soup = BeautifulSoup(req.content, "html.parser")
             title = fetch_title(soup)
-            #print("title:", title)
+            # print("title:", title)
             owner = "National Library of Scotland"
             pageurl = url
-            #print("pageurl:", pageurl)
+            # print("pageurl:", pageurl)
             asset_url = fetch_asset_url(soup)
-            #print("asset_url:", asset_url)
+            # print("asset_url:", asset_url)
             create_date = fetch_create_date(soup)
-            #print("create_date:", create_date)
+            # print("create_date:", create_date)
             file_size, file_unit = fetch_file_size(soup)
-            #print("file_size:", file_size)
-            #print("file_unit:", file_unit)
+            # print("file_size:", file_size)
+            # print("file_unit:", file_unit)
             data_type = fetch_data_types(soup)
-            #print("data_type:", data_type)
+            # print("data_type:", data_type)
             num_recs = fetch_num_recs(soup)
-            #print(("num_recs:", num_recs))
+            # print(("num_recs:", num_recs))
             nls_licence = fetch_licences(soup)
-            #print("nls_licence:", nls_licence)
+            # print("nls_licence:", nls_licence)
 
             """if title == "British Army Lists":  # Contains 4 separate download links: temporarily nulled to prevent conflicts
                 asset_url = "NULL"
@@ -402,8 +437,22 @@ if __name__ == "__main__":
                 num_recs = "NULL"
             else:"""
 
-            output = [title, owner, pageurl, asset_url, create_date, "NULL", file_size, file_unit, data_type, num_recs,
-                      "NULL", "NULL", nls_licence, "NULL", ]
+            output = [
+                title,
+                owner,
+                pageurl,
+                asset_url,
+                create_date,
+                "NULL",
+                file_size,
+                file_unit,
+                data_type,
+                num_recs,
+                "NULL",
+                "NULL",
+                nls_licence,
+                "NULL",
+            ]
             data.append(output)
 
     print("Outputting to CSV")


### PR DESCRIPTION
As per @gavbarnett's [comment](https://github.com/OpenDataScotland/the_od_bods/pull/117#issuecomment-1202151100), this formats the existing Python files using [black](https://black.readthedocs.io/en/stable/), in order to adopt a PEP-8 compatible way of unambiguously formatting code (so any PRs don't contain formatting changes too).