### PR TITLE
Issue 133

### DIFF
--- a/merge_data.py
+++ b/merge_data.py
@@ -669,6 +669,54 @@ def clean_data(dataframe):
 
     data["License"] = data["License"].apply(tidy_licence)
 
+
+    def tidy_data_type(file_type):
+        """ Temporary data type conversion
+        Args:
+            file_type (str): the data type name
+        Returns:
+            tidied_data_type (str): a tidied data type name
+        """
+        known_data_types = {
+            'plain text': 'TXT',
+            'text': 'TXT',
+            'txt': 'TXT',
+            'csv': 'CSV',
+            'tsv': 'TSV',
+            'zip': 'ZIP',
+            'html': 'HTML',
+            'image': 'Image',
+            'mets': 'XML',
+            'alto': 'XML',
+            'xml': 'XML',
+            'vnd.ms-excel': 'EXCEL Spreadsheet',
+            'xls': 'EXCEL Spreadsheet',
+            'xlsx': 'EXCEL Spreadsheet',
+            'WEB MAP': 'WEB MAP',
+            'WEB MAPPING APPLICATION': 'WEB MAP',
+            'ARCGIS GEOSERVICE': 'ARCGIS GEOSERVICE',
+            'ARCGIS GEOSERVICES REST API': 'ARCGIS GEOSERVICE',
+        }
+        tidied_data_type = "NULL"
+        print("Test", type(file_type), file_type)
+        if type(file_type) != list:
+            list_file_type = []
+            list_file_type.append(file_type)
+            file_type = list_file_type
+            print("file_type", file_type)
+        if str(file_type) == []:
+            tidied_data_type = "No file type"
+        else:
+            for data_type in file_type:
+                print("data_type", data_type)
+                if data_type in known_data_types:
+                    tidied_data_type = known_data_types[data_type]
+            # else:
+            #    tidied_data_type = "Custom file type: " + str(file_type)
+        return tidied_data_type
+
+    ### Inconsistencies in casing for FileType
+    data['FileType'] = data['FileType'].apply(tidy_data_type)
     return data
 
 

--- a/merge_data.py
+++ b/merge_data.py
@@ -669,54 +669,6 @@ def clean_data(dataframe):
 
     data["License"] = data["License"].apply(tidy_licence)
 
-
-    def tidy_data_type(file_type):
-        """ Temporary data type conversion
-        Args:
-            file_type (str): the data type name
-        Returns:
-            tidied_data_type (str): a tidied data type name
-        """
-        known_data_types = {
-            'plain text': 'TXT',
-            'text': 'TXT',
-            'txt': 'TXT',
-            'csv': 'CSV',
-            'tsv': 'TSV',
-            'zip': 'ZIP',
-            'html': 'HTML',
-            'image': 'Image',
-            'mets': 'XML',
-            'alto': 'XML',
-            'xml': 'XML',
-            'vnd.ms-excel': 'EXCEL Spreadsheet',
-            'xls': 'EXCEL Spreadsheet',
-            'xlsx': 'EXCEL Spreadsheet',
-            'WEB MAP': 'WEB MAP',
-            'WEB MAPPING APPLICATION': 'WEB MAP',
-            'ARCGIS GEOSERVICE': 'ARCGIS GEOSERVICE',
-            'ARCGIS GEOSERVICES REST API': 'ARCGIS GEOSERVICE',
-        }
-        tidied_data_type = "NULL"
-        print("Test", type(file_type), file_type)
-        if type(file_type) != list:
-            list_file_type = []
-            list_file_type.append(file_type)
-            file_type = list_file_type
-            print("file_type", file_type)
-        if str(file_type) == []:
-            tidied_data_type = "No file type"
-        else:
-            for data_type in file_type:
-                print("data_type", data_type)
-                if data_type in known_data_types:
-                    tidied_data_type = known_data_types[data_type]
-            # else:
-            #    tidied_data_type = "Custom file type: " + str(file_type)
-        return tidied_data_type
-
-    ### Inconsistencies in casing for FileType
-    data['FileType'] = data['FileType'].apply(tidy_data_type)
     return data
 
 

--- a/web-scrapers/nls_scraper.py
+++ b/web-scrapers/nls_scraper.py
@@ -310,14 +310,14 @@ def tidy_data_type(file_type):
     return tidied_data_type
 
 
-def fetch_licences(page):
+def fetch_licences(page: BeautifulSoup) -> str:
     """
     Fetches the licences, under which the specific dataset is published.
 
     Args:
         page (BeautifulSoup object): A BeautifulSoup object for the specific dataset.
     Returns:
-        list_of_licences (List): A list of licences.
+        str: A string of licences.
     """
     if not (figures := page.find_all("figure", class_="wp-block-image is-resized")):
         if not (
@@ -331,7 +331,8 @@ def fetch_licences(page):
                 )
             ):
                 return []
-    return [f.find("a").get("href") for f in figures]
+    list_of_licences = [f.find("a").get("href") for f in figures]
+    return ', '.join(str(licence) for licence in list_of_licences)
 
 
 if __name__ == "__main__":

--- a/web-scrapers/nls_scraper.py
+++ b/web-scrapers/nls_scraper.py
@@ -331,8 +331,10 @@ def fetch_licences(page: BeautifulSoup) -> str:
                 )
             ):
                 return []
-    list_of_licences = [f.find("a").get("href") for f in figures]
-    return ', '.join(str(licence) for licence in list_of_licences)
+    return [f.find("a").get("href") for f in figures][0]
+    # useful in case we want to treat the case of multiple licences per dataset:
+    # list_of_licences = [f.find("a").get("href") for f in figures]
+    # return ', '.join(str(licence) for licence in list_of_licences)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
changed fetch_licences function, so that it returns a string, instead of a list, to solve #133.

However, there are two datasets, which have two licences attached to them. These two licences are combined in one string, separated by ", ". A decision on how to treat this case is needed, since currently the tidy_licence function in merge_data.py expects the input string to only contain one licence.

The case that a dataset can contain data with two different licences seems valid, even though it had been better to separate the data based on the licence, which we cannot influence.

A merge of the current PR would be possible, to solve the more severe bug mentioned in #133, and deal with the two datasets in question later on.