### PR TITLE
CKAN and statistics.gov.scot bug fixes

### DIFF
--- a/ckan.py
+++ b/ckan.py
@@ -37,7 +37,23 @@ class ProcessorCKAN(Processor):
 
                 if 'archiver' in resource and 'size' in resource['archiver']:
                     file_size = resource['archiver']['size']
+                elif 'size' in resource:
+                    file_size = resource['size']
 
+
+                file_type = '';
+                
+                if resource['format']: 
+                    file_type = resource['format']
+                elif 'qa' in resource and 'format' in resource['qa']:
+                    file_type = resource['qa']['format']
+                elif 'resource:format' in resource:
+                    file_type = resource['resource:format']
+                elif 'service_type' in resource:
+                    file_type = resource['service_type']
+                elif 'is_wfs' in resource and resource['is_wfs'] == 'yes':
+                    file_type = 'WFS'
+                
                 prepped.append(
                     [
                         dataset_metadata['title'],  # Title
@@ -49,12 +65,12 @@ class ProcessorCKAN(Processor):
                         dataset_metadata["metadata_modified"],  # DateUpdated  
                         file_size,  # FileSize
                         "B",  # FileSizeUnit
-                        resource['format'],  # FileType
+                        file_type,  # FileType
                         None,  # NumRecords
                         ';'.join(tags),  # OriginalTags
                         None,  # ManualTags
                         dataset_metadata['license_title'],  # License
-                        dataset_metadata['notes'].encode('unicode_escape').decode()  # Description
+                        dataset_metadata['notes']  # Description
                     ]
                 )
 

--- a/export2jkan.py
+++ b/export2jkan.py
@@ -41,9 +41,9 @@ def ind(name):
         "Owner",
         "PageURL",
         "AssetURL",
+        "FileName",
         "DateCreated",
         "DateUpdated",
-        "FileName",
         "FileSize",
         "FileSizeUnit",
         "FileType",
@@ -83,7 +83,6 @@ def makeint(val):
 
 data = {}
 for r in fulld.values:
-    print(r)
     id = str(r[ind("PageURL")]) + r[ind("Title")]
     if id not in data:
         ds = Dataset(

--- a/merge_data.py
+++ b/merge_data.py
@@ -18,7 +18,7 @@ def merge_data():
                     [
                         source_ckan,
                         pd.read_csv(
-                            folder + r"/" + filename, parse_dates=["DateUpdated"], lineterminator='\n'
+                            folder + r"/" + filename, parse_dates=["DateCreated","DateUpdated"], lineterminator='\n'
                         ),
                     ]
                 )
@@ -50,7 +50,7 @@ def merge_data():
                     [
                         source_arcgis,
                         pd.read_csv(
-                            folder + r"/" + filename, parse_dates=["DateUpdated"]
+                            folder + r"/" + filename, parse_dates=["DateCreated","DateUpdated"]
                         ),
                     ]
                 )
@@ -66,7 +66,7 @@ def merge_data():
                     [
                         source_usmart,
                         pd.read_csv(
-                            folder + r"/" + filename, parse_dates=["DateUpdated"]
+                            folder + r"/" + filename, parse_dates=["DateCreated","DateUpdated"]
                         ),
                     ]
                 )
@@ -85,7 +85,7 @@ def merge_data():
                     [
                         source_dcat,
                         pd.read_csv(
-                            folder + r"/" + filename, parse_dates=["DateUpdated"]
+                            folder + r"/" + filename, parse_dates=["DateCreated","DateUpdated"]
                         ),
                     ]
                 )
@@ -102,7 +102,7 @@ def merge_data():
                     [
                         source_scraped,
                         pd.read_csv(
-                            folder + r"/" + filename, parse_dates=["DateUpdated"]
+                            folder + r"/" + filename, parse_dates=["DateCreated","DateUpdated"]
                         ),
                     ]
                 )
@@ -160,6 +160,9 @@ def clean_data(dataframe):
     }
     data["Owner"] = data["Owner"].replace(owner_renames)
     ### Format dates as datetime type
+    data["DateCreated"] = pd.to_datetime(
+        data["DateCreated"], format="%Y-%m-%d", errors="coerce", utc=True
+    ).dt.date
     data["DateUpdated"] = pd.to_datetime(
         data["DateUpdated"], format="%Y-%m-%d", errors="coerce", utc=True
     ).dt.date

--- a/sparkql_statistics.py
+++ b/sparkql_statistics.py
@@ -53,6 +53,15 @@ class ProcessorSparkQL(Processor):
         dfUnique = df.sort_values('issued', ascending=False) \
                         .drop_duplicates(subset='name', keep="first")
 
+
+        # Fallback values for those datasets missing an owner
+        for index, row in dfUnique.iterrows():
+            if pd.isnull(row['creator']):
+                if pd.isnull(row['publisher']):
+                    row['creator'] = 'Scottish Government'
+                else:
+                    row['creator'] = row['publisher']
+
         # Renaming Column Names to ODS Format
         dfOds = dfUnique \
                 .rename(columns=


### PR DESCRIPTION
Fixed a couple of issues I noticed when looking through the site:

- CKAN
    - Added in some alternative props for file size and file type
    - Removed the encode/decode for dataset description - seems to work fine now?
- Statistics.gov.scot
    - 2 of the datasets weren't getting populated with an owner. I've added in a fallback value to try another column and then if that fails then it'll fallback to a hardcoded value of "Scottish Government"
- merge_data.py and export2jkan.py
    - The file name column was in the wrong place meaning that some columns were being picked up incorrectly when exporting to JKAN
    - The date created column wasn't getting parsed or formatted during the merge process